### PR TITLE
 wallets: support decimal transforms

### DIFF
--- a/example-ws.js
+++ b/example-ws.js
@@ -14,7 +14,8 @@ const conf = {
     account: ''
   },
   transform: {
-    orderbook: { keyed: true, decimals: 4 }
+    orderbook: { keyed: true, decimals: 4 },
+    wallet: { decimals: 8 }
   }
 }
 

--- a/lib/managed-ob.js
+++ b/lib/managed-ob.js
@@ -20,20 +20,24 @@ class Orderbook {
   }
 
   parse (d) {
-    if (this.isSnapshot(d)) {
-      return this.parseSnap(d)
+    const copy = JSON.parse(JSON.stringify(d))
+
+    if (this.isSnapshot(copy)) {
+      return this.parseSnap(copy)
     }
 
-    return this.parseUpdate(d)
+    return this.parseUpdate(copy)
   }
 
   update (d) {
-    if (this.isSnapshot(d)) {
-      this.setSnapshot(d)
+    const copy = JSON.parse(JSON.stringify(d))
+
+    if (this.isSnapshot(copy)) {
+      this.setSnapshot(copy)
       return
     }
 
-    this.applyUpdate(d)
+    this.applyUpdate(copy)
   }
 
   setSnapshot (snap) {

--- a/lib/managed-wallet.js
+++ b/lib/managed-wallet.js
@@ -1,26 +1,79 @@
 'use strict'
 
 class Wallet {
-  constructor () {
+  constructor (conf = {}) {
     this.state = []
+
+    this.conf = conf
+  }
+
+  parse (d) {
+    const copy = JSON.parse(JSON.stringify(d))
+
+    if (this.isSnapshot(copy)) {
+      return this.parseSnap(copy)
+    }
+
+    return this.parseUpdate(copy)
+  }
+
+  isSnapshot (u) {
+    return Array.isArray(u[0])
+  }
+
+  parseSnap (snap) {
+    const { decimals } = this.conf
+
+    if (!decimals) {
+      return snap
+    }
+
+    const dt = this.decimalsTransformer
+    const res = snap.map((el) => {
+      el[2] = dt(el[2], decimals)
+      return el
+    })
+
+    return res
+  }
+
+  parseUpdate (update) {
+    const { decimals } = this.conf
+
+    // FIXME
+    update[1] = update[1].toUpperCase()
+
+    if (decimals) {
+      const dt = this.decimalsTransformer
+      update[2] = dt(update[2], decimals)
+    }
+
+    return update
   }
 
   update (u) {
-    if (Array.isArray(u[0])) {
-      this.setSnapshot(u)
+    const copy = JSON.parse(JSON.stringify(u))
+
+    if (this.isSnapshot(copy)) {
+      this.setSnapshot(copy)
       return
     }
 
-    this.applyUpdate(u)
+    this.applyUpdate(copy)
   }
 
   setSnapshot (snap) {
-    this.state = snap
+    const res = this.parseSnap(snap)
+
+    this.state = res
+  }
+
+  decimalsTransformer (el, decimals) {
+    return el / 10 ** decimals
   }
 
   applyUpdate (update) {
-    // FIXME
-    update[1] = update[1].toUpperCase()
+    update = this.parseUpdate(update)
 
     const [uType, uCur, uVal] = update
     let found = false

--- a/lib/mandelbrot-ws-base.js
+++ b/lib/mandelbrot-ws-base.js
@@ -141,12 +141,13 @@ class MandelbrotBase extends EventEmmiter {
 
     const id = this.getInfoHandlerId(msg[1])
     const handler = this.infoHandlers[id]
-    if (!handler) return
 
     if (id === 'info-wallet') {
-      handler(msg[2])
-      this.wallet.update(msg[2])
-      this.internalWalletHandler(msg[2])
+      const wm = msg[2]
+      if (handler) handler(this.wallet.parse(wm))
+
+      this.wallet.update(wm)
+      this.internalWalletHandler()
     }
   }
 
@@ -181,7 +182,7 @@ class MandelbrotBase extends EventEmmiter {
     handler(this.managedBooks[symbol].getState())
   }
 
-  internalWalletHandler (data) {
+  internalWalletHandler () {
     // emit onManagedWalletUpdate
     const handler = this.managedHandlers['managed-wallets']
     if (!handler) return

--- a/lib/mandelbrot-ws-base.js
+++ b/lib/mandelbrot-ws-base.js
@@ -5,7 +5,7 @@ const EventEmmiter = require('events')
 
 class MandelbrotBase extends EventEmmiter {
   constructor (opts = {
-    transform: false,
+    transform: {},
     url: null
   }) {
     super(opts)
@@ -20,7 +20,9 @@ class MandelbrotBase extends EventEmmiter {
     this.managedBooks = {}
     this.managedHandlers = {} // onMangedXyUpdate
 
-    if (opts.Wallet) this.wallet = new opts.Wallet()
+    const walletOpts = this.conf.transform.wallet
+
+    if (opts.Wallet) this.wallet = new opts.Wallet(walletOpts)
     if (opts.Orderbook) this.Orderbook = opts.Orderbook
   }
 

--- a/lib/sunbeam-ws.js
+++ b/lib/sunbeam-ws.js
@@ -10,7 +10,7 @@ const SignHelper = require('./http-order-sign.js')
 
 class MandelbrotEosfinex extends MB {
   constructor (opts = {
-    transform: false,
+    transform: {},
     url: null,
     Wallet: Wallet,
     Orderbook: Orderbook
@@ -21,7 +21,7 @@ class MandelbrotEosfinex extends MB {
     super(opts)
 
     this.signer = new SignHelper(opts)
-    this.wallet = new Wallet()
+    this.wallet = new Wallet(opts.transform.wallet)
     this.Orderbook = Ob
 
     this.managedBooks = {}

--- a/test/wallets.js
+++ b/test/wallets.js
@@ -84,4 +84,79 @@ describe('wallet helper', () => {
       [ 'exchange', 'EOS', 9600000000 ]
     ], w.getState())
   })
+
+  it('supports decimals transforms, initial snap', () => {
+    const w = new Wallet({ decimals: 8 })
+    const snap = [
+      [ 'exchange', 'USD', 9700000000 ],
+      [ 'exchange', 'ETH', 10000000000 ]
+    ]
+
+    w.update(snap)
+
+    assert.deepEqual([
+      [ 'exchange', 'USD', 97 ],
+      [ 'exchange', 'ETH', 100 ]
+    ], w.getState())
+  })
+
+  it('supports decimals transforms, update message append', () => {
+    const w = new Wallet({ decimals: 8 })
+    const snap = [
+      [ 'exchange', 'USD', 9700000000 ],
+      [ 'exchange', 'ETH', 10000000000 ]
+    ]
+
+    w.update(snap)
+
+    w.update([ 'exchange', 'EOS', 9900000000 ])
+
+    assert.deepEqual([
+      [ 'exchange', 'USD', 97 ],
+      [ 'exchange', 'ETH', 100 ],
+      [ 'exchange', 'EOS', 99 ]
+    ], w.getState())
+  })
+
+  it('supports decimals transforms, update entry replace', () => {
+    const w = new Wallet({ decimals: 8 })
+    const snap = [
+      [ 'exchange', 'USD', 9700000000 ],
+      [ 'exchange', 'ETH', 10000000000 ]
+    ]
+
+    w.update(snap)
+
+    w.update([ 'exchange', 'ETH', 9900000000 ])
+
+    assert.deepEqual([
+      [ 'exchange', 'USD', 97 ],
+      [ 'exchange', 'ETH', 99 ]
+    ], w.getState())
+  })
+
+  it('parse() calls do not affect internal state', () => {
+    const w = new Wallet({ decimals: 8 })
+    const snap = [
+      [ 'exchange', 'USD', 9700000000 ],
+      [ 'exchange', 'ETH', 9900000000 ]
+    ]
+
+    w.update(snap)
+    const u = [ 'exchange', 'ETH', 7000000000 ]
+
+    w.parse(u)
+
+    assert.deepEqual([
+      [ 'exchange', 'USD', 97 ],
+      [ 'exchange', 'ETH', 99 ]
+    ], w.getState())
+
+    w.update(u)
+
+    assert.deepEqual([
+      [ 'exchange', 'USD', 97 ],
+      [ 'exchange', 'ETH', 70 ]
+    ], w.getState())
+  })
 })


### PR DESCRIPTION
decimals support for wallet.

in eosfinex, the default is 8 decimals for wallet data, while the orderbook uses 4 decimals.

see f4333fe for enabling 8 decimals in `example-ws.js`

 - includes a small reference / deep clone fix for orderbooks

