### PR TITLE
wallets: apply format changes

### DIFF
--- a/example-wallet.js
+++ b/example-wallet.js
@@ -9,11 +9,11 @@ const {
   // simulate msg from api - snapshot
   const msg1 = [ '0',
     'ws',
-    [ [ 'exchange', 'USD', 46940000000 ],
-      [ 'exchange', 'ETH', 10000000000 ],
-      [ 'exchange', 'EUR', 10000000000 ],
-      [ 'exchange', 'EOS', 10000000000 ],
-      [ 'exchange', 'BTC', 9900000000 ] ] ]
+    [ [ 'exchange', 'USD', 46940000000, 46940000000, null ],
+      [ 'exchange', 'ETH', 10000000000, 10000000000, null ],
+      [ 'exchange', 'EUR', 10000000000, 10000000000, null ],
+      [ 'exchange', 'EOS', 10000000000, 10000000000, null ],
+      [ 'exchange', 'BTC', 9900000000, 9900000000, null ] ] ]
 
   const snap = msg1[2]
   const w = new Wallet()
@@ -38,11 +38,11 @@ const {
   // simulate msg from api - snapshot
   const msg1 = [ '0',
     'ws',
-    [ [ 'exchange', 'USD', 46940000000 ],
-      [ 'exchange', 'ETH', 10000000000 ],
-      [ 'exchange', 'EUR', 10000000000 ],
-      [ 'exchange', 'EOS', 10000000000 ],
-      [ 'exchange', 'BTC', 9900000000 ] ] ]
+    [ [ 'exchange', 'USD', 46940000000, 46940000000, null ],
+      [ 'exchange', 'ETH', 10000000000, 10000000000, null ],
+      [ 'exchange', 'EUR', 10000000000, 10000000000, null ],
+      [ 'exchange', 'EOS', 10000000000, 10000000000, null ],
+      [ 'exchange', 'BTC', 9900000000, 9900000000, null ] ] ]
 
   const snap = msg1[2]
   const w = new Wallet({ decimals: 8 })
@@ -67,11 +67,11 @@ const {
   // simulate msg from api - snapshot
   const msg1 = [ '0',
     'ws',
-    [ [ 'exchange', 'USD', 46940000000 ],
-      [ 'exchange', 'ETH', 10000000000 ],
-      [ 'exchange', 'EUR', 10000000000 ],
-      [ 'exchange', 'EOS', 10000000000 ],
-      [ 'exchange', 'BTC', 9900000000 ] ] ]
+    [ [ 'exchange', 'USD', 46940000000, 46940000000, null ],
+      [ 'exchange', 'ETH', 10000000000, 10000000000, null ],
+      [ 'exchange', 'EUR', 10000000000, 10000000000, null ],
+      [ 'exchange', 'EOS', 10000000000, 10000000000, null ],
+      [ 'exchange', 'BTC', 9900000000, 9900000000, null ] ] ]
 
   const snap = msg1[2]
   const w = new Wallet({ decimals: 8 })

--- a/lib/managed-wallet.js
+++ b/lib/managed-wallet.js
@@ -31,6 +31,8 @@ class Wallet {
     const dt = this.decimalsTransformer
     const res = snap.map((el) => {
       el[2] = dt(el[2], decimals)
+      if (el[4]) el[4] = dt(el[4], decimals)
+
       return el
     })
 
@@ -40,13 +42,13 @@ class Wallet {
   parseUpdate (update) {
     const { decimals } = this.conf
 
-    // FIXME
-    update[1] = update[1].toUpperCase()
-
     if (decimals) {
       const dt = this.decimalsTransformer
       update[2] = dt(update[2], decimals)
     }
+
+    // bfx api calc simplify
+    if (update[4] === null) update[4] = update[2]
 
     return update
   }
@@ -75,7 +77,7 @@ class Wallet {
   applyUpdate (update) {
     update = this.parseUpdate(update)
 
-    const [uType, uCur, uVal] = update
+    const [uType, uCur, uVal, uInter, uAvail] = update
     let found = false
 
     this.state = this.state.map((el) => {
@@ -85,11 +87,11 @@ class Wallet {
       if (cur !== uCur) return el
 
       found = true
-      return [uType, uCur, uVal]
+      return [uType, uCur, uVal, uInter, uAvail]
     })
 
     if (!found) {
-      this.state.push([uType, uCur, uVal])
+      this.state.push(update)
     }
   }
 

--- a/test/wallets.js
+++ b/test/wallets.js
@@ -9,8 +9,8 @@ describe('wallet helper', () => {
   it('takes snapshots', () => {
     const w = new Wallet()
     const snap = [
-      [ 'exchange', 'USD', 9700000000 ],
-      [ 'exchange', 'ETH', 10000000000 ]
+      [ 'exchange', 'USD', 98.999, 0, 98.999 ],
+      [ 'exchange', 'ETH', 100, 0, 100 ]
     ]
     w.setSnapshot(snap)
 
@@ -20,143 +20,144 @@ describe('wallet helper', () => {
   it('applies updates to snapshots', () => {
     const w = new Wallet()
     const snap = [
-      [ 'exchange', 'USD', 9700000000 ],
-      [ 'exchange', 'ETH', 10000000000 ]
+      [ 'exchange', 'USD', 98.999, 0, 98.999 ],
+      [ 'exchange', 'ETH', 100, 0, 100 ]
     ]
 
     w.setSnapshot(snap)
-    w.applyUpdate(['exchange', 'eth', 9600000000, 'testuser1414'])
+
+    w.applyUpdate(['exchange', 'ETH', 93.994, 0, null ])
 
     assert.deepEqual([
-      [ 'exchange', 'USD', 9700000000 ],
-      [ 'exchange', 'ETH', 9600000000 ]
+      [ 'exchange', 'USD', 98.999, 0, 98.999 ],
+      [ 'exchange', 'ETH', 93.994, 0, 93.994 ]
     ], w.getState())
   })
 
   it('adds new wallet types to snapshots', () => {
     const w = new Wallet()
     const snap = [
-      [ 'exchange', 'USD', 9700000000 ],
-      [ 'exchange', 'ETH', 10000000000 ]
+      [ 'exchange', 'USD', 98.999, 0, 98.999 ],
+      [ 'exchange', 'ETH', 100, 0, 100 ]
     ]
 
     w.setSnapshot(snap)
-    w.applyUpdate(['trade', 'ETH', 9600000000, 'testuser1414'])
+    w.applyUpdate(['trade', 'EOS', 99, 0, null ])
 
     assert.deepEqual([
-      [ 'exchange', 'USD', 9700000000 ],
-      [ 'exchange', 'ETH', 10000000000 ],
-      [ 'trade', 'ETH', 9600000000 ]
+      [ 'exchange', 'USD', 98.999, 0, 98.999 ],
+      [ 'exchange', 'ETH', 100, 0, 100 ],
+      [ 'trade', 'EOS', 99, 0, 99 ]
     ], w.getState())
   })
 
   it('adds new currencies to snapshots', () => {
     const w = new Wallet()
     const snap = [
-      [ 'exchange', 'USD', 9700000000 ],
-      [ 'exchange', 'ETH', 10000000000 ]
+      [ 'exchange', 'USD', 98.999, 0, 98.999 ],
+      [ 'exchange', 'ETH', 100, 0, 100 ]
     ]
 
     w.setSnapshot(snap)
-    w.applyUpdate(['exchange', 'EOS', 9600000000, 'testuser1414'])
+    w.applyUpdate(['exchange', 'EOS', 99, 0, null ])
 
     assert.deepEqual([
-      [ 'exchange', 'USD', 9700000000 ],
-      [ 'exchange', 'ETH', 10000000000 ],
-      [ 'exchange', 'EOS', 9600000000 ]
+      [ 'exchange', 'USD', 98.999, 0, 98.999 ],
+      [ 'exchange', 'ETH', 100, 0, 100 ],
+      [ 'exchange', 'EOS', 99, 0, 99 ]
     ], w.getState())
   })
 
   it('provides convinience methods that accepts snaps and updates', () => {
     const w = new Wallet()
     const snap = [
-      [ 'exchange', 'USD', 9700000000 ],
-      [ 'exchange', 'ETH', 10000000000 ]
+      [ 'exchange', 'USD', 98.999, 0, 98.999 ],
+      [ 'exchange', 'ETH', 100, 0, 100 ]
     ]
 
     w.update(snap)
 
-    w.update(['exchange', 'EOS', 9600000000, 'testuser1414'])
+    w.update(['exchange', 'EOS', 99, 0, null ])
 
     assert.deepEqual([
-      [ 'exchange', 'USD', 9700000000 ],
-      [ 'exchange', 'ETH', 10000000000 ],
-      [ 'exchange', 'EOS', 9600000000 ]
+      [ 'exchange', 'USD', 98.999, 0, 98.999 ],
+      [ 'exchange', 'ETH', 100, 0, 100 ],
+      [ 'exchange', 'EOS', 99, 0, 99 ]
     ], w.getState())
   })
 
   it('supports decimals transforms, initial snap', () => {
     const w = new Wallet({ decimals: 8 })
     const snap = [
-      [ 'exchange', 'USD', 9700000000 ],
-      [ 'exchange', 'ETH', 10000000000 ]
+      [ 'exchange', 'USD', 9700000000, 0,  9700000000 ],
+      [ 'exchange', 'ETH', 10000000000, 0, 10000000000 ]
     ]
 
     w.update(snap)
 
     assert.deepEqual([
-      [ 'exchange', 'USD', 97 ],
-      [ 'exchange', 'ETH', 100 ]
+      [ 'exchange', 'USD', 97, 0, 97 ],
+      [ 'exchange', 'ETH', 100, 0, 100 ]
     ], w.getState())
   })
 
   it('supports decimals transforms, update message append', () => {
     const w = new Wallet({ decimals: 8 })
     const snap = [
-      [ 'exchange', 'USD', 9700000000 ],
-      [ 'exchange', 'ETH', 10000000000 ]
+      [ 'exchange', 'USD', 9700000000, 0,  9700000000 ],
+      [ 'exchange', 'ETH', 10000000000, 0, 10000000000 ]
     ]
 
     w.update(snap)
 
-    w.update([ 'exchange', 'EOS', 9900000000 ])
+    w.update([ 'exchange', 'EOS', 9900000000, 0, null ])
 
     assert.deepEqual([
-      [ 'exchange', 'USD', 97 ],
-      [ 'exchange', 'ETH', 100 ],
-      [ 'exchange', 'EOS', 99 ]
+      [ 'exchange', 'USD', 97, 0, 97 ],
+      [ 'exchange', 'ETH', 100, 0, 100 ],
+      [ 'exchange', 'EOS', 99, 0, 99 ]
     ], w.getState())
   })
 
   it('supports decimals transforms, update entry replace', () => {
     const w = new Wallet({ decimals: 8 })
     const snap = [
-      [ 'exchange', 'USD', 9700000000 ],
-      [ 'exchange', 'ETH', 10000000000 ]
+      [ 'exchange', 'USD', 9700000000, 0,  9700000000 ],
+      [ 'exchange', 'ETH', 10000000000, 0, 10000000000 ]
     ]
 
     w.update(snap)
 
-    w.update([ 'exchange', 'ETH', 9900000000 ])
+    w.update([ 'exchange', 'ETH', 9900000000, 0, null ])
 
     assert.deepEqual([
-      [ 'exchange', 'USD', 97 ],
-      [ 'exchange', 'ETH', 99 ]
+      [ 'exchange', 'USD', 97, 0, 97 ],
+      [ 'exchange', 'ETH', 99, 0, 99 ]
     ], w.getState())
   })
 
   it('parse() calls do not affect internal state', () => {
     const w = new Wallet({ decimals: 8 })
     const snap = [
-      [ 'exchange', 'USD', 9700000000 ],
-      [ 'exchange', 'ETH', 9900000000 ]
+      [ 'exchange', 'USD', 9700000000, 0,  9700000000 ],
+      [ 'exchange', 'ETH', 10000000000, 0, 10000000000 ]
     ]
 
     w.update(snap)
-    const u = [ 'exchange', 'ETH', 7000000000 ]
+    const u = [ 'exchange', 'ETH', 7000000000, 0, null ]
 
     w.parse(u)
 
     assert.deepEqual([
-      [ 'exchange', 'USD', 97 ],
-      [ 'exchange', 'ETH', 99 ]
+      [ 'exchange', 'USD', 97, 0, 97 ],
+      [ 'exchange', 'ETH', 100, 0, 100 ]
     ], w.getState())
 
     w.update(u)
 
     assert.deepEqual([
-      [ 'exchange', 'USD', 97 ],
-      [ 'exchange', 'ETH', 70 ]
+      [ 'exchange', 'USD', 97, 0, 97 ],
+      [ 'exchange', 'ETH', 70, 0, 70 ]
     ], w.getState())
   })
 })


### PR DESCRIPTION
 format is now:

 ```
 [ '0',
   'ws',
   [ [ 'exchange', 'USD', 98.999, 0, 98.999 ],
     [ 'exchange', 'ETH', 100, 0, 100 ],
     [ 'exchange', 'EUR', 100, 0, 100 ],
     [ 'exchange', 'EOS', 100, 0, 100 ],
     [ 'exchange', 'BTC', 92.996, 0, 92.996 ] ] ]

[ '0', 'wu', [ 'exchange', 'USD', 99.997, 0, null ] ]