### PR TITLE
order updates: add filtered listener

### DIFF
--- a/example-ws.js
+++ b/example-ws.js
@@ -51,6 +51,23 @@ ws.on('open', () => {
     console.log(ob)
   })
 
+  // emits all updates
+  ws.onOrderUpdate({}, (data) => {
+    console.log('ws.onOrderUpdate({}')
+    console.log(data)
+  })
+
+  // filter enabled
+  ws.onOrderUpdate({ symbol: 'BTC.USD' }, (data) => {
+    console.log('ws.onOrderUpdate({ symbol: "BTC.USD" }')
+    console.log(data)
+  })
+
+  ws.onOrderUpdate({ symbol: 'ETH.USD' }, (data) => {
+    console.log('ws.onOrderUpdate({ symbol: "ETH.USD" }')
+    console.log(data)
+  })
+
   // opt-in to wallet updates
   ws.subscribeWallet()
 

--- a/lib/mandelbrot-ws-base.js
+++ b/lib/mandelbrot-ws-base.js
@@ -153,6 +153,7 @@ class MandelbrotBase extends EventEmmiter {
 
   getInfoHandlerId (id) {
     if (id === 'ws' || id === 'wu') return 'info-wallet'
+    if (id === 'on' || id === 'ou' || id === 'oc') return 'info-orders'
 
     return id
   }
@@ -169,6 +170,21 @@ class MandelbrotBase extends EventEmmiter {
 
       this.wallet.update(wm)
       this.internalWalletHandler()
+
+      return
+    }
+
+    if (id === 'info-orders') {
+      // general handler - ws.onOrderUpdate({}
+      const om = msg[2]
+      if (handler) handler(msg)
+
+      // symbol filter applied - ws.onOrderUpdate({ symbol: 'BTC.USD' }
+      const symbol = om[3]
+      const filteredHandler = this.infoHandlers[id + '-' + symbol]
+      if (filteredHandler) filteredHandler(msg)
+
+      return
     }
   }
 
@@ -182,6 +198,13 @@ class MandelbrotBase extends EventEmmiter {
 
   onWallet (filter, handler) {
     this.infoHandlers['info-wallet'] = handler
+  }
+
+  onOrderUpdate (filter, handler) {
+    const { symbol } = filter
+
+    const k =  symbol ? 'info-orders-' + symbol : 'info-orders'
+    this.infoHandlers[k] = handler
   }
 
   onManagedWalletUpdate (filter, handler) {


### PR DESCRIPTION
this will emit messages like `oc`, so the ui can show error
messages.

usage example:

```js
  // emits all updates
  ws.onOrderUpdate({}, (data) => {
    console.log('ws.onOrderUpdate({}')
    console.log(data)
  })

  // filter enabled
  ws.onOrderUpdate({ symbol: 'BTC.USD' }, (data) => {
    console.log('ws.onOrderUpdate({ symbol: "BTC.USD" }')
    console.log(data)
  })
```

example:

```js
[ '0',
  'oc',
  [ '0',
    0,
    1536169530413,
    'BTC.USD',
    1536169531,
    0,
    0,
    1,
    'testuser1554',
    'no.market' ] ]
```