### PR TITLE
permissions: make permission level configurable

### DIFF
--- a/example-http.js
+++ b/example-http.js
@@ -23,7 +23,7 @@ const eos = {
 }
 
 // dev: true allows one node for read and write
-const opts = { dev: true, account: 'testuser4321' }
+const opts = { dev: true, account: 'testuser1554', permission: '@active' }
 const sb = new Sunbeam(eos, opts)
 
 const order = sb.createOrder({

--- a/example-ws.js
+++ b/example-ws.js
@@ -11,7 +11,8 @@ const conf = {
 
     httpEndpoint: '', // used to get metadata for signing transactions
     keyProvider: [''],
-    account: ''
+    account: '',
+    permission: '@active'
   },
   transform: {
     orderbook: { keyed: true },

--- a/lib/sunbeam-ws.js
+++ b/lib/sunbeam-ws.js
@@ -27,6 +27,10 @@ class MandelbrotEosfinex extends MB {
 
     this.managedBooks = {}
     this.managedHandlers = {} // onMangedXyUpdate
+
+    if (!opts.eos.permission) {
+      opts.eos.permission = '@active'
+    }
   }
 
   auth (opts) {
@@ -83,7 +87,7 @@ class MandelbrotEosfinex extends MB {
     }
 
     const { eos } = this.conf
-    const auth = { authorization: this.conf.eos.account + '@active' }
+    const auth = { authorization: this.conf.eos.account + eos.permission }
     const signed = await this.signer.signTx(args, auth, 'cancel')
 
     const payload = [0, 'oc', null, { meta: signed }]
@@ -97,7 +101,7 @@ class MandelbrotEosfinex extends MB {
 
     const { eos } = this.conf
 
-    const auth = { authorization: this.conf.eos.account + '@active' }
+    const auth = { authorization: eos.account + eos.permission }
 
     const o = new Order(order, {})
     o.parse()

--- a/lib/sunbeam.js
+++ b/lib/sunbeam.js
@@ -42,7 +42,8 @@ class Sunbeam {
   }
 
   getAuth () {
-    return { authorization: this.conf.account + '@active' }
+    const p = this.conf.permission || '@active'
+    return { authorization: this.conf.account + p }
   }
 
   // add opts.limit when ordering by secondary indexes works again
@@ -196,7 +197,7 @@ class Sunbeam {
     this.writeEos.contract('efinexchange').then((contract) => {
       const args = order.serialize()
 
-      return contract.place(args, { authorization: args.account + '@active' })
+      return contract.place(args, { authorization: this.getAuth() })
     })
       .then((res) => {
         return cb(null, res)


### PR DESCRIPTION
 - @active stays default permission level
 - adds ability to set own permission levels

docs: https://developers.eos.io/eosio-nodeos/docs/accounts-and-permissions