### PR TITLE
 add postOnly property to orders

### DIFF
--- a/lib/order.js
+++ b/lib/order.js
@@ -46,6 +46,11 @@ class Order {
       if (!(res.flags & 4)) res.flags = res.flags + 4
     }
 
+    if (raw.postOnly) {
+      if (!res.flags) res.flags = 1
+      if (!(res.flags & 1)) res.flags = res.flags + 1
+    }
+
     res.scope = `${raw.symbol.toLowerCase()}.${this.getSide(raw.amount)}`
 
     res.amount = this.getAmount(raw.amount)

--- a/lib/order.js
+++ b/lib/order.js
@@ -48,11 +48,18 @@ class Order {
 
     res.scope = `${raw.symbol.toLowerCase()}.${this.getSide(raw.amount)}`
 
-    res.amount = raw.amount.replace('-', '')
-    res.amount = new BN(res.amount + '').mul(10000).toString()
+    res.amount = this.getAmount(raw.amount)
 
     this.parsed = res
     return this.parsed
+  }
+
+  getAmount (a) {
+    a = a + ''
+    const tmp = a.replace('-', '')
+    const amount = new BN(tmp).mul(10000).toString()
+
+    return amount
   }
 
   serialize () {

--- a/test/order.js
+++ b/test/order.js
@@ -94,6 +94,47 @@ describe('order helper', () => {
     assert.equal(ask.serialize().flags, 1)
   })
 
+  it('post only via prop supported', () => {
+    const ask = new Order({
+      symbol: 'BTC.USD',
+      amount: '-0.99',
+      type: 'EXCHANGE_LIMIT',
+      postOnly: true
+    }, conf)
+
+    ask.parse()
+
+    assert.equal(ask.serialize().flags, 1)
+  })
+
+  it('post only via prop + flag is ok', () => {
+    const ask = new Order({
+      symbol: 'BTC.USD',
+      amount: '-0.99',
+      type: 'EXCHANGE_LIMIT',
+      postOnly: true,
+      flags: 5 // 1 + 4
+    }, conf)
+
+    ask.parse()
+
+    assert.equal(ask.serialize().flags, 5)
+  })
+
+  it('postOnly prop overrides flag', () => {
+    const ask = new Order({
+      symbol: 'BTC.USD',
+      amount: '-0.99',
+      type: 'EXCHANGE_LIMIT',
+      postOnly: true,
+      flags: 0
+    }, conf)
+
+    ask.parse()
+
+    assert.equal(ask.serialize().flags, 1)
+  })
+
   it('price must be always present', () => {
     const ask = new Order({
       symbol: 'BTC.USD',


### PR DESCRIPTION
this abstraction is useful when building ui's that connect to
different endpoints which use different flags.