### PR TITLE
 withdraw: add widthdraw action

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,26 @@ ws.cancel({
 
 The request will be signed locally using the `eosjs` module.
 
+#### sunbeam.withdraw(data)
+
+- `data`
+  - `currency <String>` The currency to withdraw, e.g. `BTC`
+  - `amount <String>` The amount to withdraw
+  - `to <String> (optional)` The account to withdraw to.
+
+Withdraws tokens to a specified account.
+Defaults to account passed in constructor, `opts.eos.account`.
+
+
+*Example:*
+
+```js
+ws.withdraw({
+  currency: 'EUR',
+  amount: '0.678'
+})
+```
+
 #### `sunbeam.subscribeOrderBook(pair)`
   - `pair <String>` The pair, i.e. `BTC.USD`
 

--- a/README.md
+++ b/README.md
@@ -200,6 +200,12 @@ The request will be signed locally using the `eosjs` module.
 
 #### `sunbeam.cancel(data)`
 
+  - `data`
+    - `symbol <String>` The pair, i.e. `BTC.USD`
+    - `side <String>` `bid` or `ask`
+    - `id <String>` The id returned from the contract on placement
+    - `clientId <String>` The unique id assigned by the client
+
 Cancels an order.
 
 *Example:*

--- a/lib/mandelbrot-ws-base.js
+++ b/lib/mandelbrot-ws-base.js
@@ -114,9 +114,7 @@ class MandelbrotBase extends EventEmitter {
     delete this._managedState['books'][symbol]
   }
 
-  unSubscribeOrders () {
-    this.unsubscribe('reports')
-  }
+  unSubscribeOrders () {}
 
   subscribe (channel, opts) {
     const msg = {

--- a/lib/sunbeam-ws.js
+++ b/lib/sunbeam-ws.js
@@ -115,6 +115,10 @@ class MandelbrotEosfinex extends MB {
     const payload = [0, 'on', null, { meta: signed }]
     this.send(payload)
   }
+
+  unSubscribeOrders () {
+    this.unsubscribe('reports')
+  }
 }
 
 module.exports = MandelbrotEosfinex

--- a/lib/sunbeam-ws.js
+++ b/lib/sunbeam-ws.js
@@ -116,6 +116,30 @@ class MandelbrotEosfinex extends MB {
     this.send(payload)
   }
 
+  async withdraw (data) {
+    const { eos } = this.conf
+
+    const { to, currency, amount } = data
+
+    if (amount[0] === '-') {
+      throw new Error('amount must be positive')
+    }
+
+    const amountPad = eos.Eos.modules.format.DecimalPad(amount, 8)
+    const amountPlusCurrency = `${amountPad} ${currency}`
+
+    const args = {
+      amount: amountPlusCurrency,
+      to: to || eos.account
+    }
+
+    const auth = { authorization: eos.account + eos.permission }
+    const signed = await this.signer.signTx(args, auth, 'withdraw')
+
+    const payload = [0, 'tx', null, { meta: signed }]
+    this.send(payload)
+  }
+
   unSubscribeOrders () {
     this.unsubscribe('reports')
   }


### PR DESCRIPTION
`to` property is optional, defaults to account.

```js
  ws.withdraw({
    currency: 'EUR',
    amount: '0.678'
  })
```
---
included:

docs: add cancel argument properties

small refactor:
 - unsubscribe orders: stub in base, implement in sb