### PR TITLE
 add feature to prefetch contract abis

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,10 @@ You can see all API calls in [example-ws.js](example-ws.js).
     - `eos <Object>` options passed to Eos client for signing transactions
       - `expireInSeconds <Number>` Expiration time for signed tx
       - `Eos <Class>` The official eosjs client Class from `require('eosjs')`
-      - `httpEndpoint <String>` an Eos node HTTP endpoint, used to get metadata for signing transactions
+      - `httpEndpoint <String>` an Eos node HTTP endpoint, used to get the contract abi, if abi not passed via options. omit when you pass the abi via options
+      - `abis <Object> (optional)` eosfinex contract abis, so no initial http request is required to get the contract abi and httpEndpoint can be omitted
+        - `exchange <Object>` Exchange abi
+        - `token <Object>` Token contract abi
       - `keyProvider <String>` your key, used to sign transactions
       - `account <String>` accountname to use for the key
       - `permission <String>` permission level to use for the account
@@ -51,7 +54,8 @@ const opts = {
   eos: {
     expireInSeconds: 60 * 60, // 1 hour,
     Eos: Eos,
-    httpEndpoint: 'https://eosnode.example.com:8888', // used to get metadata for signing transactions
+    httpEndpoint: 'https://eosnode.example.com:8888',
+    abis: null, // fetched via http from eos node if null
     keyProvider: [''], // your key, used to sign transactions
     account: '', //
     permission: '@active'
@@ -66,6 +70,9 @@ const opts = {
 const ws = new Sunbeam(opts)
 ws.open()
 ```
+
+For an example how to prefetch the contract abis to avoid the initial
+HTTP request to an eos node, see [example-prefetched-abi-ws.js](example-prefetched-abi-ws.js).
 
 ### Events emitted
 

--- a/example-prefetched-abi-ws.js
+++ b/example-prefetched-abi-ws.js
@@ -1,0 +1,85 @@
+'use strict'
+
+const Sunbeam = require('.')
+
+const Eos = require('eosjs')
+const eos = Eos({
+  httpEndpoint: 'http://eosnode.example.com:8888', // used to get metadata for signing transactions
+  keyProvider: [],
+  verbose: false
+})
+
+;(async () => {
+  const efinexchangeAbi = await eos.getAbi('efinexchange')
+  const efinextetherAbi = await eos.getAbi('efinextether')
+
+  const conf = {
+    url: 'wss://eosnode-withws.example.com',
+    eos: {
+      expireInSeconds: 60 * 60, // 1 hour,
+      Eos: Eos,
+      httpEndpoint: 'http://eosnode.example.com:8888', // used to get metadata for signing transactions
+      keyProvider: [''],
+      account: '',
+      permission: '@active',
+      abis: {
+        exchange: efinexchangeAbi.abi,
+        token: efinextetherAbi.abi
+      }
+    },
+    transform: {
+      orderbook: { keyed: true },
+      wallet: {},
+      orders: { keyed: true }
+    }
+  }
+
+  console.log('got abis:', Object.keys(conf.eos.abis))
+
+  const ws = new Sunbeam(conf)
+
+  ws.on('message', (m) => {
+    console.log(m)
+  })
+
+  ws.on('error', (m) => {
+    console.error('ERROR!')
+    console.error(m)
+  })
+
+  ws.on('open', () => {
+    ws.onWallet({}, (wu) => {
+      console.log('ws.onWalletUpdate')
+      console.log(wu)
+    })
+
+    ws.onManagedOrderbookUpdate({ symbol: 'BTC.USD' }, (ob) => {
+      console.log('ws.onManagedOrderbookUpdate({ symbol: "BTC.USD" }')
+      console.log(ob)
+    })
+
+    ws.auth()
+    ws.subscribeOrderBook('BTC.USD')
+
+    const order = {
+      symbol: 'BTC.USD',
+      price: '1',
+      amount: '1',
+      type: 'EXCHANGE_LIMIT'
+    }
+    ws.place(order)
+
+    /*
+    ws.sweep({
+      currency: 'EUR'
+    })
+
+    ws.deposit({
+      currency: 'EUR',
+      amount: '2'
+    })
+    */
+  })
+
+  ws.open()
+})()

--- a/lib/http-order-sign.js
+++ b/lib/http-order-sign.js
@@ -9,14 +9,21 @@ class SignHelper {
     this.conf = opts
 
     this.metaEos = null
-    this.abi = null // abi is needed to construct the tx data
+
+    // abis needed to construct the tx data
+    const abis = {
+      exchange: null,
+      token: null
+    }
+
+    this.abis = this.conf.eos.abis || abis
 
     this.initMetaEos()
   }
 
   initMetaEos () {
     return new Promise((resolve) => {
-      const { Eos, httpEndpoint, keyProvider } = this.conf.eos
+      const { Eos, httpEndpoint } = this.conf.eos
 
       if (this.metaEos && this.exchangeAbi && this.tokenAbi) {
         return resolve()
@@ -28,7 +35,7 @@ class SignHelper {
         verbose: false
       })
 
-      if (this.exchangeAbi && this.tokenAbi) {
+      if (this.abis.exchange && this.abis.token) {
         return resolve()
       }
 
@@ -38,10 +45,10 @@ class SignHelper {
 
   getExchangeAbi () {
     return new Promise((resolve) => {
-      if (this.exchangeAbi) return resolve()
+      if (this.abis.exchange) return resolve()
 
       this.metaEos.getAbi('efinexchange').then((res) => {
-        this.exchangeAbi = res.abi
+        this.abis.exchange = res.abi
         resolve()
       })
         .catch((err) => {
@@ -53,10 +60,10 @@ class SignHelper {
 
   getTokenAbi () {
     return new Promise((resolve) => {
-      if (this.tokenAbi) return resolve()
+      if (this.abis.token) return resolve()
 
       this.metaEos.getAbi('efinextether').then((res) => {
-        this.tokenAbi = res.abi
+        this.abis.token = res.abi
         resolve()
       })
         .catch((err) => {
@@ -125,7 +132,7 @@ class SignHelper {
   async signTx (payload, auth, action) {
     const signingEos = await this.prepareSign()
 
-    signingEos.fc.abiCache.abi('efinexchange', this.exchangeAbi)
+    signingEos.fc.abiCache.abi('efinexchange', this.abis.exchange)
     const contract = await signingEos.contract('efinexchange')
 
     const transfer = await contract[action](payload, auth)
@@ -137,7 +144,7 @@ class SignHelper {
   async signDeposit (payload, auth) {
     const signingEos = await this.prepareSign()
 
-    signingEos.fc.abiCache.abi('efinextether', this.tokenAbi)
+    signingEos.fc.abiCache.abi('efinextether', this.abis.token)
     const contract = await signingEos.contract('efinextether')
 
     const transfer = await contract.transfer(payload, auth)

--- a/lib/http-order-sign.js
+++ b/lib/http-order-sign.js
@@ -31,7 +31,7 @@ class SignHelper {
 
       this.metaEos = Eos({
         httpEndpoint,
-        keyProvider,
+        keyProvider: [],
         verbose: false
       })
 


### PR DESCRIPTION
this removes the requirement for initial http calls to an eos node,
so in the future, sunbeam is able to run on ws only, if needed.