### PR TITLE
sign: receive metadata for tx headers from websocket

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ You can see all API calls in [example-ws.js](example-ws.js).
     - `eos <Object>` options passed to Eos client for signing transactions
       - `expireInSeconds <Number>` Expiration time for signed tx
       - `Eos <Class>` The official eosjs client Class from `require('eosjs')`
-      - `httpEndpoint <String>` an Eos node HTTP endpoint, used to get the contract abi, if abi not passed via options. omit when you pass the abi via options
+      - `httpEndpoint <String|null>` an Eos node HTTP endpoint, used to get the contract abi, if abi not passed via options. omit when you pass the abi via options
       - `abis <Object> (optional)` eosfinex contract abis, so no initial http request is required to get the contract abi and httpEndpoint can be omitted
         - `exchange <Object>` Exchange abi
         - `token <Object>` Token contract abi

--- a/lib/order-sign.js
+++ b/lib/order-sign.js
@@ -1,8 +1,8 @@
 'use strict'
 
 // this is a helper class for signing transactions
-// currently it depends on metadata obtained by a
-// nodeos http endpoint
+// if abis are not passed via constuctor, it depends on initial http calls
+// to get contract abis from an eos node.
 
 class SignHelper {
   constructor (opts) {
@@ -80,30 +80,31 @@ class SignHelper {
     ])
   }
 
-  async getTxHeaders (eos, opts) {
+  getTxHeaders (meta, opts) {
     const { expireInSeconds } = opts
 
-    const info = await eos.getInfo({})
-    const chainDate = new Date(info.head_block_time + 'Z')
-    let expiration = new Date(chainDate.getTime() + expireInSeconds * 1000)
-    expiration = expiration.toISOString().split('.')[0]
+    const [
+      headBlockTime,
+      lastIrreversibleBlockNumber,
+      chainId,
+      refBlockPrefix
+    ] = meta
 
-    const block = await eos.getBlock(info.last_irreversible_block_num)
+    let expiration = new Date(+headBlockTime * 1000 + (expireInSeconds * 1000))
+    expiration = expiration.toISOString().split('.')[0]
 
     const transactionHeaders = {
       expiration,
-      ref_block_num: info.last_irreversible_block_num & 0xFFFF,
-      ref_block_prefix: block.ref_block_prefix
+      ref_block_num: lastIrreversibleBlockNumber & 0xFFFF,
+      ref_block_prefix: +refBlockPrefix
     }
 
-    return [ transactionHeaders, info.chain_id ]
+    return [ transactionHeaders, chainId ]
   }
 
-  async prepareSign () {
-    await this.initMetaEos()
-
+  async prepareSign (meta) {
     const { expireInSeconds } = this.conf.eos
-    const [ transactionHeaders, chainId ] = await this.getTxHeaders(this.metaEos, { expireInSeconds })
+    const [ transactionHeaders, chainId ] = await this.getTxHeaders(meta, { expireInSeconds })
 
     const { Eos, keyProvider } = this.conf.eos
 
@@ -129,8 +130,8 @@ class SignHelper {
     return fixed
   }
 
-  async signTx (payload, auth, action) {
-    const signingEos = await this.prepareSign()
+  async signTx (payload, auth, action, meta) {
+    const signingEos = await this.prepareSign(meta)
 
     signingEos.fc.abiCache.abi('efinexchange', this.abis.exchange)
     const contract = await signingEos.contract('efinexchange')
@@ -141,8 +142,8 @@ class SignHelper {
     return fixed
   }
 
-  async signDeposit (payload, auth) {
-    const signingEos = await this.prepareSign()
+  async signDeposit (payload, auth, meta) {
+    const signingEos = await this.prepareSign(meta)
 
     signingEos.fc.abiCache.abi('efinextether', this.abis.token)
     const contract = await signingEos.contract('efinextether')

--- a/lib/sunbeam-ws.js
+++ b/lib/sunbeam-ws.js
@@ -7,7 +7,8 @@ const Wallet = require('./managed-wallet.js')
 const Orderbook = require('./managed-ob.js')
 const Orders = require('./managed-orders.js')
 
-const SignHelper = require('./http-order-sign.js')
+const SignHelper = require('./order-sign.js')
+const Cbq = require('cbq')
 
 class MandelbrotEosfinex extends MB {
   constructor (opts = {
@@ -28,10 +29,13 @@ class MandelbrotEosfinex extends MB {
     if (!opts.Orders) opts.Orders = Or
     const W = opts.Wallet || Wallet
     if (!opts.Wallet) opts.Wallet = W
+    opts.requestTimeout = opts.requestTimeout || 10000
 
     super(opts)
 
     if (opts.eos.Eos) this.signer = new SignHelper(opts)
+
+    this.cbq = new Cbq()
   }
 
   auth (opts) {
@@ -57,6 +61,51 @@ class MandelbrotEosfinex extends MB {
       channel: 'wallets',
       account: account
     })
+  }
+
+  requestChainMeta () {
+    return new Promise((resolve, reject) => {
+      const limit = this.conf.requestTimeout
+      const reqId = Math.floor(Math.random() * 10E+15)
+      let timeout
+
+      const cb = (msg) => {
+        clearTimeout(timeout)
+        this.cbq.trigger(reqId, null, msg)
+
+        resolve(msg)
+      }
+      this.once('ci', cb)
+
+      timeout = setTimeout(() => {
+        this.cbq.trigger(reqId, new Error('ERR_TIMEOUT'))
+      }, limit)
+
+      this.cbq.push(reqId, (err, res) => {
+        clearTimeout(timeout)
+
+        if (err) {
+          this.removeListener('ci', cb)
+          return reject(err)
+        }
+
+        resolve(res)
+      })
+
+      this.send({
+        event: 'chain'
+      })
+    })
+  }
+
+  handleInfoMessage (m) {
+    super.handleInfoMessage(m)
+
+    const [, id, data] = m
+
+    if (id === 'ci') {
+      this.emit('ci', data)
+    }
   }
 
   unSubscribeWallet () {
@@ -107,7 +156,8 @@ class MandelbrotEosfinex extends MB {
     }
 
     const auth = this.getAuth()
-    const signed = await this.signer.signTx(args, auth, 'cancel')
+    const meta = await this.requestChainMeta()
+    const signed = await this.signer.signTx(args, auth, 'cancel', meta)
 
     const payload = [0, 'oc', null, { meta: signed }]
     this.send(payload)
@@ -120,14 +170,15 @@ class MandelbrotEosfinex extends MB {
 
     const { eos } = this.conf
 
-    const auth = this.getAuth()
+    const auth = { authorization: eos.account + eos.permission }
+    const meta = await this.requestChainMeta()
 
     const o = new Order(order, {})
     o.parse()
     o.maybeSetUser(eos.account)
     const serialized = o.serialize()
 
-    const signed = await this.signer.signTx(serialized, auth, 'place')
+    const signed = await this.signer.signTx(serialized, auth, 'place', meta)
 
     const payload = [0, 'on', null, { meta: signed }]
     this.send(payload)
@@ -151,7 +202,8 @@ class MandelbrotEosfinex extends MB {
     }
 
     const auth = this.getAuth()
-    const signed = await this.signer.signTx(args, auth, 'withdraw')
+    const meta = await this.requestChainMeta()
+    const signed = await this.signer.signTx(args, auth, 'withdraw', meta)
 
     const payload = [0, 'tx', null, { meta: signed }]
     this.send(payload)
@@ -167,7 +219,8 @@ class MandelbrotEosfinex extends MB {
     }
 
     const auth = this.getAuth()
-    const signed = await this.signer.signTx(args, auth, 'sweep')
+    const meta = await this.requestChainMeta()
+    const signed = await this.signer.signTx(args, auth, 'sweep', meta)
 
     const payload = [0, 'tx', null, { meta: signed }]
     this.send(payload)
@@ -193,7 +246,8 @@ class MandelbrotEosfinex extends MB {
     }
 
     const auth = this.getAuth()
-    const signed = await this.signer.signDeposit(args, auth)
+    const meta = await this.requestChainMeta()
+    const signed = await this.signer.signDeposit(args, auth, meta)
 
     const payload = [0, 'tx', null, { meta: signed }]
     this.send(payload)

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@babel/polyfill": "^7.0.0",
     "@babel/runtime": "^7.0.0",
     "big.js": "^5.1.2",
+    "cbq": "git+https://github.com/bitfinexcom/cbq-js.git",
     "eosjs": "^16.0.0",
     "isomorphic-ws": "^4.0.1",
     "ws": "^6.0.0"


### PR DESCRIPTION
gets the required data for tx signing from the websocket instead
of an eos node http endpoint.