### PR TITLE
do not crash on invalid message

### DIFF
--- a/lib/mandelbrot-ws-base.js
+++ b/lib/mandelbrot-ws-base.js
@@ -193,6 +193,11 @@ class MandelbrotBase extends EventEmitter {
       return
     }
 
+    if (!this._channels['book'][chanId]) {
+      console.error('received invalid channel id from api, id:', chanId)
+      return
+    }
+
     const { symbol } = this._channels['book'][chanId]
     const tOpts = this.conf.transform.orderbook
 


### PR DESCRIPTION
message without subscription would throw an error, e.g.

`[ '', [] ]`