### PR TITLE
scatter support: support scatter for auth

### DIFF
--- a/example-prefetched-abi-ws.js
+++ b/example-prefetched-abi-ws.js
@@ -19,9 +19,14 @@ const eos = Eos({
       expireInSeconds: 60 * 60, // 1 hour,
       Eos: Eos,
       httpEndpoint: 'http://eosnode.example.com:8888', // used to get metadata for signing transactions
-      keyProvider: [''],
-      account: '',
-      permission: '@active',
+      auth: {
+        keys: {
+          keyProvider: [''],
+          account: '',
+          permission: '@active'
+        },
+        scatter: null
+      },
       abis: {
         exchange: efinexchangeAbi.abi,
         token: efinextetherAbi.abi

--- a/example-scatter.js
+++ b/example-scatter.js
@@ -1,0 +1,99 @@
+'use strict'
+
+const Sunbeam = require('./lib/sunbeam-ws.js')
+const Eos = require('eosjs')
+
+// https://github.com/GetScatter/scatter-js/issues/47
+const Websocket = require('isomorphic-ws')
+global.WebSocket = Websocket
+
+let ScatterJS = require('scatterjs-core')
+if (ScatterJS.default) {
+  // package was precompiled for babel es6 modules
+  ScatterJS = ScatterJS.default
+}
+
+let ScatterEOS = require('scatterjs-plugin-eosjs')
+if (ScatterEOS.default) {
+  // package was precompiled for babel es6 modules
+  ScatterEOS = ScatterEOS.default
+}
+
+ScatterJS.plugins(new ScatterEOS())
+
+const conf = {
+  url: 'wss://eosnode-withws.example.com',
+  eos: {
+    expireInSeconds: 60 * 60, // 1 hour,
+    Eos: Eos,
+    httpEndpoint: 'http://eosnode.example.com:8888', // used to get metadata for signing transactions
+    auth: {
+      scatter: {
+        ScatterJS,
+        appName: 'Eosfinex-Demo-Scatter'
+      },
+      keys: null
+    }
+  },
+  transform: {
+    orderbook: { keyed: true },
+    wallet: {},
+    orders: { keyed: true }
+  }
+}
+
+const ws = new Sunbeam(conf)
+
+ws.on('message', (m) => {
+  console.log(m)
+})
+
+ws.on('error', (m) => {
+  console.error('ERROR!')
+  console.error(m)
+})
+
+ws.on('open', async () => {
+  console.log(await ws.auth())
+  console.log(await ws.auth()) // cached
+
+  ws.onOrderBook({ symbol: 'IQX.USD' }, (ob) => {
+    console.log('ws.onOrderBook({ symbol: "IQX.USD" }')
+    console.log(ob)
+  })
+
+  ws.subscribeOrderBook('IQX.USD')
+
+  const order = {
+    symbol: 'IQX.USD',
+    price: '1',
+    amount: '1',
+    type: 'EXCHANGE_LIMIT'
+  }
+
+  const { payload, data } = await ws.place(order)
+  ws.cancel({
+    symbol: 'IQX.USD',
+    side: 'bid',
+    id: '18446744073709551606',
+    clientId: '1540306547501022'
+  })
+
+/*
+  ws.deposit({
+    currency: 'EOS',
+    amount: '2'
+  })
+
+  ws.withdraw({
+    currency: 'EOS',
+    amount: '0.678'
+  })
+
+  ws.sweep({
+    currency: 'EOS'
+  })
+*/
+})
+
+ws.open()

--- a/example-ws.js
+++ b/example-ws.js
@@ -4,15 +4,19 @@ const Sunbeam = require('./lib/sunbeam-ws.js')
 const Eos = require('eosjs')
 
 const conf = {
-  url: '',
+  url: 'wss://eosnode-withws.example.com',
   eos: {
     expireInSeconds: 60 * 60, // 1 hour,
     Eos: Eos,
-
-    httpEndpoint: '', // used to get metadata for signing transactions
-    keyProvider: [''],
-    account: '',
-    permission: '@active'
+    httpEndpoint: 'http://eosnode.example.com:8888', // used to get metadata for signing transactions
+    auth: {
+      keys: {
+        keyProvider: [''],
+        account: '',
+        permission: '@active'
+      },
+      scatter: null
+    }
   },
   transform: {
     orderbook: { keyed: true },

--- a/lib/order-sign.js
+++ b/lib/order-sign.js
@@ -4,6 +4,11 @@
 // if abis are not passed via constuctor, it depends on initial http calls
 // to get contract abis from an eos node.
 
+let URL
+if (typeof window === 'undefined') {
+  URL = require('url').URL
+}
+
 class SignHelper {
   constructor (opts) {
     this.conf = opts
@@ -16,9 +21,20 @@ class SignHelper {
       token: null
     }
 
-    this.abis = this.conf.eos.abis || abis
+    const eos = this.conf.eos
+    this.abis = eos.abis || abis
 
+    this.checkAuthOptions()
     this.initMetaEos()
+  }
+
+  checkAuthOptions (eos) {
+    const { auth } = this.conf.eos
+    if (auth.scatter && auth.keys) {
+      throw new Error(
+        'auth must be scatter or keys based, not both. check auth options.'
+      )
+    }
   }
 
   initMetaEos () {
@@ -102,17 +118,41 @@ class SignHelper {
     return [ transactionHeaders, chainId ]
   }
 
-  async prepareSign (meta) {
+  prepareSign (meta) {
     const { expireInSeconds } = this.conf.eos
-    const [ transactionHeaders, chainId ] = await this.getTxHeaders(meta, { expireInSeconds })
+    const [ transactionHeaders, chainId ] = this.getTxHeaders(meta, { expireInSeconds })
 
-    const { Eos, keyProvider } = this.conf.eos
+    const { Eos, auth, httpEndpoint } = this.conf.eos
 
+    if (auth.keys) {
+      const signingEos = Eos({
+        httpEndpoint: null,
+        chainId,
+        keyProvider: auth.keys.keyProvider,
+        transactionHeaders,
+        broadcast: false,
+        verbose: false,
+        sign: true
+      })
+
+      return signingEos
+    }
+
+    const parsed = new URL(httpEndpoint)
+    const network = {
+      blockchain: 'eos',
+      protocol: parsed.protocol.replace(':', ''),
+      host: parsed.hostname,
+      port: parsed.port,
+      chainId: chainId
+    }
+
+    const scatter = auth.scatter.ScatterJS.scatter
     const signingEos = Eos({
       httpEndpoint: null,
       chainId,
-      keyProvider,
       transactionHeaders,
+      signProvider: scatter.eosHook(network),
       broadcast: false,
       verbose: false,
       sign: true
@@ -130,28 +170,43 @@ class SignHelper {
     return fixed
   }
 
-  async signTx (payload, auth, action, meta) {
-    const signingEos = await this.prepareSign(meta)
+  signTx (payload, auth, action, meta) {
+    return new Promise(async (resolve, reject) => {
+      try {
+        const signingEos = this.prepareSign(meta)
 
-    signingEos.fc.abiCache.abi('efinexchange', this.abis.exchange)
-    const contract = await signingEos.contract('efinexchange')
+        signingEos.fc.abiCache.abi('efinexchange', this.abis.exchange)
+        const contract = await signingEos.contract('efinexchange')
 
-    const transfer = await contract[action](payload, auth)
-    const fixed = this.fixTx(transfer)
+        const { authorization } = auth
 
-    return fixed
+        const transfer = await contract[action](payload, authorization)
+        const fixed = this.fixTx(transfer)
+
+        resolve(fixed)
+      } catch (e) {
+        reject(e)
+      }
+    })
   }
 
-  async signDeposit (payload, auth, meta) {
-    const signingEos = await this.prepareSign(meta)
+  signDeposit (payload, auth, meta) {
+    return new Promise(async (resolve, reject) => {
+      try {
+        const signingEos = this.prepareSign(meta)
 
-    signingEos.fc.abiCache.abi('efinextether', this.abis.token)
-    const contract = await signingEos.contract('efinextether')
+        signingEos.fc.abiCache.abi('efinextether', this.abis.token)
+        const contract = await signingEos.contract('efinextether')
 
-    const transfer = await contract.transfer(payload, auth)
-    const fixed = this.fixTx(transfer)
+        const { authorization } = auth
+        const transfer = await contract.transfer(payload, authorization)
+        const fixed = this.fixTx(transfer)
 
-    return fixed
+        resolve(fixed)
+      } catch (e) {
+        reject(e)
+      }
+    })
   }
 }
 

--- a/lib/sunbeam-ws.js
+++ b/lib/sunbeam-ws.js
@@ -10,6 +10,11 @@ const Orders = require('./managed-orders.js')
 const SignHelper = require('./order-sign.js')
 const Cbq = require('cbq')
 
+let URL
+if (typeof window === 'undefined') {
+  URL = require('url').URL
+}
+
 class MandelbrotEosfinex extends MB {
   constructor (opts = {
     transform: {},
@@ -34,15 +39,22 @@ class MandelbrotEosfinex extends MB {
     super(opts)
 
     if (opts.eos.Eos) this.signer = new SignHelper(opts)
+    this.account = null
+    this.chainId = null
 
     this.cbq = new Cbq()
   }
 
   auth (opts) {
-    const { account } = this.conf.eos
+    return this.getAuth()
+      .then((auth) => {
+        const { account } = auth
 
-    const payload = { event: 'auth', account: account }
-    this.send(payload)
+        const payload = { event: 'auth', account: account }
+        this.send(payload)
+
+        return auth
+      })
   }
 
   subscribePublicTrades (symbol) {
@@ -54,13 +66,16 @@ class MandelbrotEosfinex extends MB {
   }
 
   subscribeWallet () {
-    const { account } = this.conf.eos
+    return this.getAuth()
+      .then((auth) => {
+        const { account } = auth
 
-    this.send({
-      event: 'subscribe',
-      channel: 'wallets',
-      account: account
-    })
+        this.send({
+          event: 'subscribe',
+          channel: 'wallets',
+          account: account
+        })
+      })
   }
 
   requestChainMeta () {
@@ -124,133 +139,262 @@ class MandelbrotEosfinex extends MB {
     return symbol.toLowerCase() + '.' + s
   }
 
-  getAuth () {
-    const { eos } = this.conf
-    return { authorization: eos.account + eos.permission }
+  getChainId () {
+    return new Promise((resolve, reject) => {
+      if (this.chainId) return resolve(this.chainId)
+
+      this.requestChainMeta().then((meta) => {
+        const [ , , chainId ] = meta
+
+        this.chainId = chainId
+        resolve(this.chainId)
+      })
+    })
   }
 
-  async cancel (data) {
-    const { eos } = this.conf
-    const { clientId, id, symbol, side } = data
+  setupScatter () {
+    return new Promise((resolve, reject) => {
+      if (this.scatterConnected) return resolve()
 
-    const scope = this.getScope(symbol, side)
-    const args = {
-      scope: scope,
-      account: eos.account
-    }
 
-    if (clientId) {
-      args.clId = clientId
-    }
+      const { auth } = this.conf.eos
+      const appName = auth.scatter.appName
 
-    if (!args.clId) {
-      args.clId = 0
-    }
+      const scatter = this.getScatterInstance()
+      scatter.connect(appName).then(connected => {
+        if (!connected) return reject(new Error('scatter not running.'))
 
-    if (id) {
-      args.id = id
-    }
-
-    if (!this.signer) {
-      throw new Error('please initialise Sunbeam with Eos.')
-    }
-
-    const auth = this.getAuth()
-    const meta = await this.requestChainMeta()
-    const signed = await this.signer.signTx(args, auth, 'cancel', meta)
-
-    const payload = [0, 'oc', null, { meta: signed }]
-    this.send(payload)
+        this.scatterConnected = true
+        resolve()
+      })
+    })
   }
 
-  async place (order) {
-    if (!this.signer) {
-      throw new Error('please initialise Sunbeam with Eos.')
-    }
-
-    const { eos } = this.conf
-
-    const auth = { authorization: eos.account + eos.permission }
-    const meta = await this.requestChainMeta()
-
-    const o = new Order(order, {})
-    o.parse()
-    o.maybeSetUser(eos.account)
-    const serialized = o.serialize()
-
-    const signed = await this.signer.signTx(serialized, auth, 'place', meta)
-
-    const payload = [0, 'on', null, { meta: signed }]
-    this.send(payload)
+  getScatterInstance () {
+    const { auth } = this.conf.eos
+    return auth.scatter.ScatterJS.scatter
   }
 
-  async withdraw (data) {
-    const { eos } = this.conf
+  loginScatter () {
+    return new Promise(async (resolve, reject) => {
+      const scatter = this.getScatterInstance()
 
-    const { to, currency, amount } = data
+      try {
+        const chainId = await this.getChainId()
+        const { httpEndpoint } = this.conf.eos
+        const parsed = new URL(httpEndpoint)
 
-    if (amount[0] === '-') {
-      throw new Error('amount must be positive')
-    }
+        const network = {
+          blockchain: 'eos',
+          protocol: parsed.protocol.replace(':', ''),
+          host: parsed.hostname,
+          port: parsed.port,
+          chainId: chainId
+        }
 
-    const amountPad = eos.Eos.modules.format.DecimalPad(amount, 8)
-    const amountPlusCurrency = `${amountPad} ${currency}`
-
-    const args = {
-      amount: amountPlusCurrency,
-      to: to || eos.account
-    }
-
-    const auth = this.getAuth()
-    const meta = await this.requestChainMeta()
-    const signed = await this.signer.signTx(args, auth, 'withdraw', meta)
-
-    const payload = [0, 'tx', null, { meta: signed }]
-    this.send(payload)
+        await scatter.suggestNetwork(network)
+        await scatter.getIdentity({ accounts: [network] })
+        const account = scatter.identity.accounts.find(x => x.blockchain === 'eos')
+        resolve(account)
+      } catch (e) {
+        reject(e)
+      }
+    })
   }
 
-  async sweep (data) {
-    const { eos } = this.conf
-    const { currency, to } = data
-
-    const args = {
-      symbol: currency.toLowerCase(),
-      to: to || eos.account
-    }
-
-    const auth = this.getAuth()
-    const meta = await this.requestChainMeta()
-    const signed = await this.signer.signTx(args, auth, 'sweep', meta)
-
-    const payload = [0, 'tx', null, { meta: signed }]
-    this.send(payload)
+  logoutScatter () {
+    return new Promise((resolve, reject) => {
+      const scatter = this.getScatterInstance()
+      scatter.forgetIdentity()
+      resolve()
+    })
   }
 
-  async deposit (data) {
-    const { eos } = this.conf
-    const { currency, amount } = data
+  getAuth (cached) {
+    return new Promise((resolve, reject) => {
+      if (this.account) {
+        resolve(this.account)
+        return
+      }
 
-    if (amount[0] === '-') {
-      throw new Error('amount must be positive')
-    }
+      const { auth } = this.conf.eos
 
-    const amountPad = eos.Eos.modules.format.DecimalPad(amount, 8)
-    const amountPlusCurrency = `${amountPad} ${currency}`
+      if (auth.keys) {
+        const res = {
+          authorization: { authorization: auth.keys.account + auth.keys.permission },
+          account: auth.keys.account
+        }
 
-    const args = {
-      from: eos.account,
-      to: 'efinexchange',
-      quantity: amountPlusCurrency,
-      memo: '',
-      account: 'efinextether'
-    }
+        this.account = res
 
-    const auth = this.getAuth()
-    const meta = await this.requestChainMeta()
-    const signed = await this.signer.signDeposit(args, auth, meta)
+        return resolve(res)
+      }
 
-    const payload = [0, 'tx', null, { meta: signed }]
-    this.send(payload)
+      this.setupScatter()
+        .then(() => { return this.loginScatter() })
+        .then((account) => {
+          const res = {
+            authorization: {
+              authorization: account.name + '@' + account.authority
+            },
+            account: account.name
+          }
+
+          this.account = res
+
+          return resolve(res)
+        }).catch(reject)
+    })
+  }
+
+  cancel (data) {
+    return new Promise(async (resolve, reject) => {
+      try {
+        const { clientId, id, symbol, side } = data
+
+        const auth = await this.getAuth()
+
+        const scope = this.getScope(symbol, side)
+        const args = {
+          scope: scope,
+          account: auth.account
+        }
+
+        if (clientId) {
+          args.clId = clientId
+        }
+
+        if (!args.clId) {
+          args.clId = 0
+        }
+
+        if (id) {
+          args.id = id
+        }
+
+        const meta = await this.requestChainMeta()
+        const signed = await this.signer.signTx(args, auth, 'cancel', meta)
+
+        const payload = [0, 'oc', null, { meta: signed }]
+        this.send(payload)
+        resolve({ payload, data: args })
+      } catch (e) {
+        reject(e)
+      }
+    })
+  }
+
+  place (order) {
+    return new Promise(async (resolve, reject) => {
+      try {
+        const auth = await this.getAuth()
+        const meta = await this.requestChainMeta()
+
+        const o = new Order(order, {})
+        o.parse()
+        o.maybeSetUser(auth.account)
+        const serialized = o.serialize()
+
+        const signed = await this.signer.signTx(serialized, auth, 'place', meta)
+
+        const payload = [0, 'on', null, { meta: signed }]
+        this.send(payload)
+        resolve({ payload, data: o.parsed })
+      } catch (e) {
+        reject(e)
+      }
+    })
+  }
+
+  withdraw (data) {
+    return new Promise(async (resolve, reject) => {
+      try {
+        const { eos } = this.conf
+
+        const { to, currency, amount } = data
+
+        if (amount[0] === '-') {
+          throw new Error('amount must be positive')
+        }
+
+        const amountPad = eos.Eos.modules.format.DecimalPad(amount, 8)
+        const amountPlusCurrency = `${amountPad} ${currency}`
+
+        const auth = await this.getAuth()
+        const args = {
+          amount: amountPlusCurrency,
+          to: to || auth.account
+        }
+
+        const meta = await this.requestChainMeta()
+        const signed = await this.signer.signTx(args, auth, 'withdraw', meta)
+
+        const payload = [0, 'tx', null, { meta: signed }]
+        this.send(payload)
+        resolve({ payload, data: args })
+      } catch (e) {
+        reject(e)
+      }
+    })
+  }
+
+  sweep (data) {
+    return new Promise(async (resolve, reject) => {
+      try {
+        const { eos } = this.conf
+        const { currency, to } = data
+
+        const auth = await this.getAuth()
+        const args = {
+          symbol: currency.toLowerCase(),
+          to: to || auth.account
+        }
+
+        const meta = await this.requestChainMeta()
+        const signed = await this.signer.signTx(args, auth, 'sweep', meta)
+
+        const payload = [0, 'tx', null, { meta: signed }]
+        this.send(payload)
+        resolve({ payload, data: args })
+      } catch (e) {
+        reject(e)
+      }
+    })
+  }
+
+  deposit (data) {
+    return new Promise(async (resolve, reject) => {
+      try {
+        const { eos } = this.conf
+        const { currency, amount } = data
+
+        if (amount[0] === '-') {
+          throw new Error('amount must be positive')
+        }
+
+        const auth = await this.getAuth()
+
+        const amountPad = eos.Eos.modules.format.DecimalPad(amount, 8)
+        const amountPlusCurrency = `${amountPad} ${currency}`
+
+        const args = {
+          from: auth.account,
+          to: 'efinexchange',
+          quantity: amountPlusCurrency,
+          memo: '',
+          account: 'efinextether'
+        }
+
+        const meta = await this.requestChainMeta()
+        const signed = await this.signer.signDeposit(args, auth, meta)
+
+        const payload = [0, 'tx', null, { meta: signed }]
+        this.send(payload)
+        resolve({ payload, data: args })
+      } catch (e) {
+        reject(e)
+      }
+    })
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -30,6 +30,8 @@
     "babelify": "^9.0.0",
     "browserify": "^16.2.2",
     "mocha": "^5.2.0",
+    "scatterjs-core": "^2.3.7",
+    "scatterjs-plugin-eosjs": "^1.3.7",
     "standard": "^12.0.0"
   },
   "dependencies": {


### PR DESCRIPTION
other changes:
 -  added `logoutScatter()`to end scatter session 
 - all async methods to create transactions return a promise now,
   e.g. `place()`, `cancel()` [...] the promise resolves with the
   sent payload and the data:

```js
  const { payload, data } = await ws.place(order)
  console.log(data.clientId) // use in cancel method
```

this is also useful for error handling.

 - `auth()` returns a Promise now
 - `getChainId()` is a new method to retrieve the chain id, which
    is then cached for later use. internally used for the scatter
    auth flow.