### PR TITLE
Fix require URL for browsers

### DIFF
--- a/lib/order-sign.js
+++ b/lib/order-sign.js
@@ -4,9 +4,9 @@
 // if abis are not passed via constuctor, it depends on initial http calls
 // to get contract abis from an eos node.
 
-let URL
-if (typeof window === 'undefined') {
-  URL = require('url').URL
+let URL = require('url').URL
+if (typeof window !== 'undefined') {
+  URL = window.URL
 }
 
 class SignHelper {

--- a/lib/sunbeam-ws.js
+++ b/lib/sunbeam-ws.js
@@ -10,9 +10,9 @@ const Orders = require('./managed-orders.js')
 const SignHelper = require('./order-sign.js')
 const Cbq = require('cbq')
 
-let URL
-if (typeof window === 'undefined') {
-  URL = require('url').URL
+let URL = require('url').URL
+if (typeof window !== 'undefined') {
+  URL = window.URL
 }
 
 class MandelbrotEosfinex extends MB {

--- a/package.json
+++ b/package.json
@@ -47,5 +47,8 @@
   "browserslist": [
     "IE 11",
     "Safari 11"
-  ]
+  ],
+  "browser": {
+    "url": false
+  }
 }


### PR DESCRIPTION
The URL require was failing in browsers, this PR flips the check around and removes the browserify url shim (reducing dist size from 185k to 140k)