### PR TITLE
auth: sign verification transaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,11 @@ ws.close()
 #### `sunbeam.auth() => Promise`
 
 Takes the account name you have defined when creating a Sunbeam instance with
-`opts.eos.account` and sends it to the server. Your private key stays local.
+`opts.eos.account`. Your private key stays local.
+
+It will sign a verification transaction that is send to the Websocket endpoint
+for validation. This transaction is not applied to the chain, just used for
+verifying the signature.
 
 If you configured auth via scatter, it will connect to scatter. Remember to remove
 any global references to ScatterJS **and any global references to Sunbeam**:

--- a/lib/sunbeam-ws.js
+++ b/lib/sunbeam-ws.js
@@ -53,15 +53,22 @@ class MandelbrotEosfinex extends MB {
   }
 
   auth (opts) {
-    return this.getAuth()
-      .then((auth) => {
-        const { account } = auth
+    return new Promise(async (resolve, reject) => {
+      const auth = await this.getAuth()
+      const signed = await this.getTestTx()
 
-        const payload = { event: 'auth', account: account }
-        this.send(payload)
+      const { account } = auth
 
-        return auth
-      })
+      const payload = {
+        event: 'auth',
+        account: account,
+        meta: signed
+      }
+
+      this.send(payload)
+
+      resolve(auth)
+    })
   }
 
   subscribePublicTrades (symbol) {


### PR DESCRIPTION
it signs a verification transaction that is send to the
Websocket endpoint for validation. This transaction is not applied
to the chain, just used for verifying the signature.