### PR TITLE
Fix auth call preventing errors

### DIFF
--- a/lib/sunbeam-ws.js
+++ b/lib/sunbeam-ws.js
@@ -54,20 +54,24 @@ class MandelbrotEosfinex extends MB {
 
   auth (opts) {
     return new Promise(async (resolve, reject) => {
-      const auth = await this.getAuth()
-      const signed = await this.getTestTx()
+      try {
+        const auth = await this.getAuth()
+        const signed = await this.getTestTx()
 
-      const { account } = auth
+        const { account } = auth
 
-      const payload = {
-        event: 'auth',
-        account: account,
-        meta: signed
+        const payload = {
+          event: 'auth',
+          account: account,
+          meta: signed
+        }
+
+        this.send(payload)
+
+        resolve(auth)
+      } catch (e) {
+        reject(e)
       }
-
-      this.send(payload)
-
-      resolve(auth)
     })
   }
 


### PR DESCRIPTION
Previously errors were not reported as the await would error inside the promise call method. I've updated this method to look like the others.

@robertkowalski is there a reason we wrap these methods with a promise, could they not be async methods that return the resolved value?