### PR TITLE
orders: add markDeleted feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ You can see all API calls in [example-ws.js](example-ws.js).
       - `wallet <Object>`
       - `orders <Object>`
         - `keyed <Boolean>` Manage state as keyed Objects instead of an Array
+        - `markDeleted <Boolean>` cancelled orders are flagged as deleted, but not removed from the state
 
 
 ```js

--- a/lib/managed-orders.js
+++ b/lib/managed-orders.js
@@ -13,10 +13,25 @@ class Orders extends MB.BaseOrders {
   }
 
   deleteFromKeyed (update) {
+    const { markDeleted } = this.conf
     const parsed = this.getKeyedFromArray(update)
 
     const uClientId = parsed.clientId
     const uSymbol = parsed.symbol
+
+    if (markDeleted) {
+      this.state = this.state.map((el) => {
+        const { clientId, symbol } = el
+
+        if (clientId === uClientId && symbol === uSymbol) {
+          el.deleted = true
+        }
+
+        return el
+      })
+
+      return
+    }
 
     this.state = this.state.filter((el) => {
       const { clientId, symbol } = el
@@ -30,7 +45,22 @@ class Orders extends MB.BaseOrders {
   }
 
   deleteFromRaw (update) {
+    const { markDeleted } = this.conf
     const [ , , UClId, Usymbol ] = update
+
+    if (markDeleted) {
+      this.state = this.state.map((el) => {
+        const [ , , clId, symbol ] = el
+
+        if (clId === UClId && symbol === Usymbol) {
+          el.push('deleted')
+        }
+
+        return el
+      })
+
+      return
+    }
 
     this.state = this.state.filter((el) => {
       const [ , , clId, symbol ] = el

--- a/test/orders.js
+++ b/test/orders.js
@@ -163,6 +163,26 @@ describe('orders helper', () => {
     assert.deepStrictEqual(o.getState(), [ snap[0], snap[1] ])
   })
 
+  it('update oc, mark deleted', () => {
+    const o = new Orders({ markDeleted: true })
+    o.update(snapMsg)
+
+    const snap = snapMsg[2]
+    // add order
+    o.update(onMsg)
+    assert.deepStrictEqual(o.getState(), [ snap[0], snap[1], onMsg[2] ])
+    assert.strictEqual(o.getState().length, 3)
+
+    // delete it
+    o.update(ocMsg)
+
+    const marked = o.getState()[2]
+    assert.strictEqual(marked.pop(), 'deleted')
+
+    assert.strictEqual(o.getState()[1].pop(), null) // nothing added to other msg
+    assert.strictEqual(o.getState().length, 3)
+  })
+
   it('supports keyed format, snaps', () => {
     const o = new Orders({ keyed: true })
     o.update(snapMsg)
@@ -254,5 +274,19 @@ describe('orders helper', () => {
       [state[0].id, state[1].id]
     )
     assert.strictEqual(o.getState().length, 2)
+  })
+
+  it('supports keyed format, delete', () => {
+    const o = new Orders({ keyed: true, markDeleted: true })
+    o.update(snapMsg)
+    o.update(onMsg)
+
+    assert.strictEqual(o.getState().length, 3)
+    o.update(ocMsg)
+
+    const state = o.getState()
+    assert.strictEqual(state[0].deleted, undefined)
+    assert.strictEqual(state[1].deleted, undefined)
+    assert.strictEqual(state[2].deleted, true)
   })
 })


### PR DESCRIPTION
does not delete cancelled orders (`oc`) from the state and marks
them as deleted