### PR TITLE
Fixed so a default port is suggested if one is not explicitly set

### DIFF
--- a/lib/sunbeam-ws.js
+++ b/lib/sunbeam-ws.js
@@ -192,11 +192,18 @@ class MandelbrotEosfinex extends MB.WsBase {
         const { httpEndpoint } = this.conf.eos
         const parsed = new URL(httpEndpoint)
 
+        // if the port is not explicitly set in the given endpoint,
+        // set it based on the protocol
+        const protocol = parsed.protocol.replace(':', '')
+        const port = parsed.port
+          ? parsed.port
+          : (protocol === 'https') ? 443 : 80
+
         const network = {
           blockchain: 'eos',
-          protocol: parsed.protocol.replace(':', ''),
+          protocol,
           host: parsed.hostname,
-          port: parsed.port,
+          port,
           chainId: chainId
         }
 


### PR DESCRIPTION
When using 'Connect with Scatter' I got an error like:
> {type: "bad_network", message: "The network being suggested is invalid", code: 423, isError: true}

If the given endpoint URL didn't have a specified port, no port would be given to the scatter endpoint. Which resulted in the above error.
(at least on my local Windows machine + jeffrey.lozier reported it. Doesn't seem to have been a general issue for everyone...?).

Made a fix, where it will assume the port number based on the protocol, if no port has been explicitly set.