### PR TITLE
tx signing: use request timeout for tx signing, too

### DIFF
--- a/lib/order-sign.js
+++ b/lib/order-sign.js
@@ -175,6 +175,10 @@ class SignHelper {
   signTx (payload, auth, action, meta) {
     return new Promise(async (resolve, reject) => {
       try {
+        const t = setTimeout(() => {
+          reject(new Error('ERR_TX_SIGN_TIMEOUT'))
+        }, this.conf.requestTimeout)
+
         const signingEos = this.prepareSign(meta)
         const { exchangeContract } = this.conf.eos
 
@@ -186,6 +190,7 @@ class SignHelper {
         const transfer = await contract[action](payload, authorization)
         const fixed = this.fixTx(transfer)
 
+        clearTimeout(t)
         resolve(fixed)
       } catch (e) {
         reject(e)
@@ -196,6 +201,10 @@ class SignHelper {
   signDeposit (payload, auth, meta) {
     return new Promise(async (resolve, reject) => {
       try {
+        const t = setTimeout(() => {
+          reject(new Error('ERR_TX_SIGN_TIMEOUT'))
+        }, this.conf.requestTimeout)
+
         const { tokenContract } = this.conf.eos
         const signingEos = this.prepareSign(meta)
 
@@ -206,6 +215,7 @@ class SignHelper {
         const transfer = await contract.transfer(payload, authorization)
         const fixed = this.fixTx(transfer)
 
+        clearTimeout(t)
         resolve(fixed)
       } catch (e) {
         reject(e)


### PR DESCRIPTION
time out connection in case we don't get a response for signing,
e.g. when using wrong urls or when the backend is down.