### PR TITLE
scatter: remove request timeouts

### DIFF
--- a/lib/order-sign.js
+++ b/lib/order-sign.js
@@ -175,10 +175,6 @@ class SignHelper {
   signTx (payload, auth, action, meta) {
     return new Promise(async (resolve, reject) => {
       try {
-        const t = setTimeout(() => {
-          reject(new Error('ERR_TX_SIGN_TIMEOUT'))
-        }, this.conf.requestTimeout)
-
         const signingEos = this.prepareSign(meta)
         const { exchangeContract } = this.conf.eos
 
@@ -190,7 +186,6 @@ class SignHelper {
         const transfer = await contract[action](payload, authorization)
         const fixed = this.fixTx(transfer)
 
-        clearTimeout(t)
         resolve(fixed)
       } catch (e) {
         reject(e)
@@ -201,10 +196,6 @@ class SignHelper {
   signDeposit (payload, auth, meta) {
     return new Promise(async (resolve, reject) => {
       try {
-        const t = setTimeout(() => {
-          reject(new Error('ERR_TX_SIGN_TIMEOUT'))
-        }, this.conf.requestTimeout)
-
         const { tokenContract } = this.conf.eos
         const signingEos = this.prepareSign(meta)
 
@@ -215,7 +206,6 @@ class SignHelper {
         const transfer = await contract.transfer(payload, authorization)
         const fixed = this.fixTx(transfer)
 
-        clearTimeout(t)
         resolve(fixed)
       } catch (e) {
         reject(e)

--- a/lib/sunbeam-ws.js
+++ b/lib/sunbeam-ws.js
@@ -208,6 +208,11 @@ class MandelbrotEosfinex extends MB.WsBase {
           chainId: chainId
         }
 
+        const hasAccount = await scatter.hasAccountFor(network)
+        if (!hasAccount) {
+          throw new Error('ERR_NO_SCATTER_ACCOUNT')
+        }
+
         await scatter.suggestNetwork(network)
         await scatter.getIdentity({ accounts: [network] })
         const account = scatter.identity.accounts.find(x => x.blockchain === 'eos')


### PR DESCRIPTION
 - scatter requests often take longer, removing the timeout again
 - when no account in scatter was found, return with an error