### PR TITLE
 decimalPad: add DecimalString from eosjs@16

### DIFF
--- a/lib/sunbeam-ws.js
+++ b/lib/sunbeam-ws.js
@@ -314,7 +314,7 @@ class MandelbrotEosfinex extends MB.WsBase {
           throw new Error('amount must be positive')
         }
 
-        const amountPad = eos.Eos.modules.format.DecimalPad(amount, 8)
+        const amountPad = decimalPad(amount, 8)
         const amountPlusCurrency = `${amountPad} ${currency}`
 
         const auth = await this.getAuth()

--- a/lib/util.js
+++ b/lib/util.js
@@ -4,7 +4,7 @@
 // MIT license
 exports.decimalPad = decimalPad
 function decimalPad (num, precision) {
-  const value = num + ''
+  const value = decimalString(num)
 
   if (!precision) {
     return value
@@ -28,4 +28,36 @@ function decimalPad (num, precision) {
   }
 
   return `${part[0]}.${part[1]}${'0'.repeat(pad)}`
+}
+
+// taken from https://github.com/EOSIO/eosjs/blob/v16.0.9/src/format.js
+// MIT license
+function decimalString (value) {
+  if (!value) throw new Error('value required')
+
+  value = value.toString ? value.toString() : value + ''
+
+  const neg = /^-/.test(value)
+  if (neg) {
+    value = value.substring(1)
+  }
+
+  if (value[0] === '.') {
+    value = `0${value}`
+  }
+
+  const part = value.split('.')
+
+  if (part.length === 2) {
+    part[1] = part[1].replace(/0+$/, '')// remove suffixing zeros
+    if (part[1] === '') {
+      part.pop()
+    }
+  }
+
+  part[0] = part[0].replace(/^0*/, '')// remove leading zeros
+  if (part[0] === '') {
+    part[0] = '0'
+  }
+  return (neg ? '-' : '') + part.join('.')
 }

--- a/test/int-sub-unsub-ob.js
+++ b/test/int-sub-unsub-ob.js
@@ -28,17 +28,17 @@ describe('managed state - sub unsub, state stays nice', () => {
       url: 'ws://localhost:8888',
       eos: {
         expireInSeconds: 60 * 60, // 1 hour,
-        Eos: null,
         httpEndpoint: '',
         keyProvider: [''], //
-        account: 'testuser1554'
+        account: 'testuser1554',
+        auth: {}
       },
       transform: {
         orderbook: { keyed: false },
         wallet: {}
       }
     }
-    const sws = new Sunbeam(conf)
+    const sws = new Sunbeam({}, conf)
 
     let subscriptions = 0
     wss.messageHook = (ws, msg) => {

--- a/test/util.js
+++ b/test/util.js
@@ -1,0 +1,20 @@
+/* eslint-env mocha */
+
+'use strict'
+
+const { decimalPad } = require('../lib/util.js')
+const assert = require('assert')
+
+describe('util', () => {
+  it('decimalpad supports leading zeros', () => {
+    assert.strictEqual(decimalPad('96.88000000', 8), '96.88000000')
+  })
+
+  it('decimalpad adds padding', () => {
+    assert.strictEqual(decimalPad('96.88', 8), '96.88000000')
+  })
+
+  it('decimalpad removes excess padding', () => {
+    assert.strictEqual(decimalPad('96.88000000', 3), '96.880')
+  })
+})


### PR DESCRIPTION
`DecimalString` in eosjs@16 is removing trailign zeros, which is
required for `Decimalpad` to calculate the proper padding for
values with trailing zeros, i.e. `98.3000`.