### PR TITLE
allow auth config to be passed to auth method

### DIFF
--- a/lib/sunbeam-ws.js
+++ b/lib/sunbeam-ws.js
@@ -65,7 +65,31 @@ class MandelbrotEosfinex extends MB.WsBase {
     this.cbq = new Cbq()
   }
 
-  auth (opts) {
+  setAuth (auth = {}) {
+    const {
+      keys,
+      client,
+      scatter
+    } = auth
+
+    if (keys && client) {
+      this.conf.eos.auth.keys = keys
+      this.client = client
+      this.signer = new SignHelper(this.client, this.conf)
+      return
+    }
+
+    this.scatter = new SunbeamScatter({
+      appName: scatter.appName,
+      ScatterJS: scatter.ScatterJS
+    })
+  }
+
+  auth (auth) {
+    if (auth) {
+      this.setAuth(auth)
+    }
+
     return new Promise(async (resolve, reject) => {
       try {
         const auth = await this.getAuth()


### PR DESCRIPTION
this change allows authentication configuration to be added after
sunbeam is instantiated

---

rebased & standard linted version of #104 