### PR TITLE
scatter: suggest network before checking account

### DIFF
--- a/lib/scatter.js
+++ b/lib/scatter.js
@@ -60,13 +60,13 @@ class SunbeamScatter {
         const scatter = this.scatterInstance
 
         await scatter.forgetIdentity()
+        await scatter.suggestNetwork(network)
 
         const hasAccount = await scatter.hasAccountFor(network)
         if (!hasAccount) {
           throw new Error('ERR_NO_SCATTER_ACCOUNT')
         }
 
-        await scatter.suggestNetwork(network)
         await scatter.getIdentity({ accounts: [network] })
         const account = scatter.identity.accounts.find(x => x.blockchain === 'eos')
         const signProvider = scatter.eosHook(network, null, true)


### PR DESCRIPTION
Move `suggestNetwork` before `hasAccountFor` check to prevent error from `hasAccountFor` if the network does not exist in Scatter.