### PR TITLE
scatter: remove forgetIdentity from login

### DIFF
--- a/lib/scatter.js
+++ b/lib/scatter.js
@@ -59,7 +59,6 @@ class SunbeamScatter {
       try {
         const scatter = this.scatterInstance
 
-        await scatter.forgetIdentity()
         await scatter.suggestNetwork(network)
 
         const hasAccount = await scatter.hasAccountFor(network)


### PR DESCRIPTION
Remove `scatter.forgetIdentity` to prevent already selected identity from being reset when logging in