### PR TITLE
scatter: add forgetIdentity after initial connection

### DIFF
--- a/lib/scatter.js
+++ b/lib/scatter.js
@@ -40,17 +40,19 @@ class SunbeamScatter {
   }
 
   setupScatter () {
-    return new Promise((resolve, reject) => {
+    return new Promise(async (resolve, reject) => {
       if (this.scatterConnected) return resolve()
 
       const { appName } = this.opts
+      const scatter = this.scatterInstance
 
-      this.scatterInstance.connect(appName).then((connected) => {
-        if (!connected) return reject(new Error('ERR_SCATTER_NOT_RUNNING'))
+      const connected = await scatter.connect(appName)
+      if (!connected) return reject(new Error('ERR_SCATTER_NOT_RUNNING'))
 
-        this.scatterConnected = true
-        resolve()
-      })
+      await scatter.forgetIdentity()
+
+      this.scatterConnected = true
+      resolve()
     })
   }
 


### PR DESCRIPTION
adds a request to `scatter.forgetIdentity` after scatter connection has been established. 