### PR TITLE
factor out history support, add `getSignedTx` helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,6 @@ You can see all API calls in [example-ws.js](example-ws.js).
     - `api` official eosjs Api class instance
   - `opts <Object>`
     - `url <String>` Address of the Websocket eosfinex node
-    - `moonbeam <String>` optional HTTP server to retrieve historical data
     - `eos <Object>` options passed to Eos client for signing transactions
       - `expireInSeconds <Number>` Expiration time for signed tx
       - `httpEndpoint <String|null>` an Eos node HTTP endpoint, used to get the contract abi, if abi not passed via options.
@@ -111,7 +110,6 @@ const client = {
 // setup sunbeam
 const opts = {
   url: 'wss://api-paper.eosfinex.com/ws/',
-  moonbeam: 'https://api-paper.eosfinex.com/rest',
   eos: {
     expireInSeconds: 60 * 60, // 1 hour,
     httpEndpoint: httpEndpoint, // used to get metadata for signing transactions
@@ -254,6 +252,42 @@ Where `signed` is a signed transaction for the `validate` action.
 
 Accepts the terms of service. Must be called before `.auth()`
 
+
+#### `sunbeam.getSignedTx(?user) => Promise`
+
+  - `user <Object>` optional user object. if not defined, will use the data provided in the constructor or retrieve it from scatter
+
+Signs a transaction that can be used for login on the WS server for custom auth flows.
+
+Example:
+
+```js
+const user = {
+  authorization: {
+    authorization: "testuser1114@active"
+  },
+  account: "testuser1114",
+  permission: "active"
+}
+
+const signed = await ws.getSignedTx(user)
+
+const getData = (data) => {
+  return {
+    method: 'POST',
+    body: JSON.stringify(data),
+    headers: { 'Content-Type': 'application/json' }
+  }
+}
+
+// get history
+const history = await fetch(moonbeamUrl + '/history', getData({
+  meta: signed,
+  limit: 50
+})).then(res => res.json())
+
+console.log(history)
+```
 
 #### `sunbeam.logoutScatter() => Promise`
 
@@ -635,19 +669,6 @@ ws.unsubscribe('wallets', { account: 'testuser1431' })
   channel: 'wallets',
   account: 'testuser1431'
 }
-```
-
-
-#### `sunbeam.requestHistory() => Promise`
-
-Sends a verification transaction to a moonbeam server
-to receive the trading history.
-
-*Example:*
-
-```js
-const history = await ws.requestHistory()
-console.log(history)
 ```
 
 #### Websocket API helper RPC calls

--- a/example-scatter.js
+++ b/example-scatter.js
@@ -38,7 +38,6 @@ const client = {
 
 const conf = {
   url: 'wss://api-paper.eosfinex.com/ws/',
-  moonbeam: 'https://api-paper.eosfinex.com/rest',
   eos: {
     expireInSeconds: 60 * 60, // 1 hour,
     httpEndpoint: httpEndpoint, // used to get metadata for signing transactions

--- a/lib/sunbeam-ws.js
+++ b/lib/sunbeam-ws.js
@@ -16,7 +16,6 @@ const SunbeamScatter = require('./scatter.js')
 const { decimalPad } = require('./util.js')
 
 const Cbq = require('cbq')
-const fetch = require('node-fetch')
 
 const tokenContract = 'eosio.token'
 const exchangeContract = 'efinexchange'
@@ -88,6 +87,21 @@ class MandelbrotEosfinex extends MB.WsBase {
     this.tos = version
   }
 
+  sendAuth (user, signed) {
+    this.account = user
+
+    const { account } = user
+
+    const payload = {
+      event: 'auth',
+      account: account,
+      meta: signed,
+      agree: this.tos
+    }
+
+    this.send(payload)
+  }
+
   auth (data) {
     return new Promise(async (resolve, reject) => {
       try {
@@ -98,18 +112,8 @@ class MandelbrotEosfinex extends MB.WsBase {
         }
 
         const auth = await this.getAuth()
-        const signed = await this.getTestTx()
-
-        const { account } = auth
-
-        const payload = {
-          event: 'auth',
-          account: account,
-          meta: signed,
-          agree: this.tos
-        }
-
-        this.send(payload)
+        const signed = await this.getSignedTx()
+        this.sendAuth(auth, signed)
 
         resolve(auth)
       } catch (e) {
@@ -224,7 +228,7 @@ class MandelbrotEosfinex extends MB.WsBase {
     return network
   }
 
-  getAuth (cached) {
+  getAuth () {
     return new Promise((resolve, reject) => {
       if (this.account) {
         resolve(this.account)
@@ -401,59 +405,22 @@ class MandelbrotEosfinex extends MB.WsBase {
     })
   }
 
-  getTestTx () {
-    return new Promise(async (resolve, reject) => {
-      try {
-        const auth = await this.getAuth()
-        const args = {}
-        const { exchangeContract } = this.conf.eos
+  async getSignedTx (user) {
+    const auth = user || await this.getAuth()
 
-        const meta = await this.requestChainMeta()
-        const signed = await this.signer.signTx(
-          args,
-          auth,
-          'validate',
-          meta,
-          exchangeContract
-        )
+    const args = {}
+    const { exchangeContract } = this.conf.eos
 
-        resolve(signed)
-      } catch (e) {
-        reject(e)
-      }
-    })
-  }
+    const meta = await this.requestChainMeta()
+    const signed = await this.signer.signTx(
+      args,
+      auth,
+      'validate',
+      meta,
+      exchangeContract
+    )
 
-  requestHistory (opts = {}) {
-    return new Promise(async (resolve, reject) => {
-      try {
-        const { moonbeam } = this.conf
-
-        if (!opts.limit) opts.limit = 50
-
-        const signed = await this.getTestTx()
-
-        const payload = {
-          meta: signed,
-          limit: opts.limit
-        }
-
-        const data = {
-          method: 'POST',
-          body: JSON.stringify(payload),
-          headers: { 'Content-Type': 'application/json' }
-        }
-
-        fetch(moonbeam + '/history', data)
-          .then(res => res.json())
-          .then(json => {
-            resolve({ data: payload, res: json })
-          })
-          .catch(reject)
-      } catch (e) {
-        reject(e)
-      }
-    })
+    return signed
   }
 
   sendReqRes (req, cb) {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "babelify": "^9.0.0",
     "browserify": "^16.2.2",
     "mocha": "^5.2.0",
+    "node-fetch": "^2.2.1",
     "scatterjs-core": "^2.7.17",
     "scatterjs-plugin-eosjs2": "^1.5.0",
     "standard": "^12.0.0"
@@ -42,7 +43,6 @@
     "eosjs": "^20.0.0",
     "isomorphic-ws": "^4.0.1",
     "mandelbrot": "https://github.com/bitfinexcom/mandelbrot.git#7bf653dbaaeee255ce6c8b76353e56d6ca2f4505",
-    "node-fetch": "^2.2.1",
     "ws": "^6.1.0"
   },
   "browserslist": [


### PR DESCRIPTION
signed transactions are used as auth mechanism for different
things: tos handling, trade history and websocket auth.

in the future, probably more endpoints are going to be added.

for auth mechanism like scatter, this means right now, that a login
to the ui needs multiple transactions signed by the user, which
results in a bad ux.

to provide maximum flexibilty in the future, this removes
the built-in moonbeam request wrapper. a client can request a
tx with `getSignedTx` now, that can be used for their tos, ws-auth
and history handling, until the tx expires by the defined
timeframe.