### PR TITLE
websockets: support multiple connections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ app.js
 package-lock.json
 
 dist/*
+config/*.json

--- a/config/example-ws.config.json.example
+++ b/config/example-ws.config.json.example
@@ -1,0 +1,29 @@
+{
+  "staging": {
+    "keys": ["__SECRET__"],
+
+    "urls": {
+      "pub": "ws://__API__",
+      "priv": "ws://__API__",
+      "aux": "ws://__API__"
+    },
+    "eos": {
+      "expireInSeconds": 3600,
+      "httpEndpoint": "http://__API__",
+      "auth": {
+        "keys": {
+          "account": "__ACCOUNT__",
+          "permission": "active"
+        },
+        "scatter": null
+      }
+    },
+    "state": {
+      "transform": {
+        "orderbook": { "keyed": true },
+        "wallet": {},
+        "orders": {}
+      }
+    }
+  }
+}

--- a/example-ws.js
+++ b/example-ws.js
@@ -2,16 +2,20 @@
 
 const Sunbeam = require('.')
 
+const config = require('./config/example-ws.config.json')
+const env = 'staging'
+const opts = config[env]
+
+const keys = opts.keys
+const httpEndpoint = opts.eos.httpEndpoint
+
 const { Api, JsonRpc } = require('eosjs')
 const { JsSignatureProvider } = require('eosjs/dist/eosjs-jssig')
 
 const fetch = require('node-fetch')
 const { TextDecoder, TextEncoder } = require('util')
-const keys = ['SECRET']
 
 const signatureProvider = new JsSignatureProvider(keys)
-
-const httpEndpoint = 'https://api-paper.eosfinex.com'
 
 const rpc = new JsonRpc(httpEndpoint, { fetch })
 const api = new Api({
@@ -27,33 +31,11 @@ const client = {
 }
 
 // setup sunbeam
-const opts = {
-  url: 'wss://api-paper.eosfinex.com/ws/',
-  moonbeam: 'https://api-paper.eosfinex.com/rest',
-  eos: {
-    expireInSeconds: 60 * 60, // 1 hour,
-    httpEndpoint: httpEndpoint, // used to get metadata for signing transactions
-    tokenContract: 'eosio.token', // Paper sidechain token contract
-    exchangeContract: 'eosfinex', // Paper sidechain exchange contract
-    auth: {
-      keys: {
-        account: '', // accountname to use
-        permission: 'active'
-      },
-      scatter: null
-    }
-  },
-  transform: {
-    orderbook: { keyed: true },
-    wallet: {},
-    orders: { keyed: true }
-  }
-}
-
 const ws = new Sunbeam(client, opts)
 
-ws.on('message', (m) => {
-  console.log(m)
+ws.on('message', (m, t) => {
+  console.log('------- msg -----')
+  console.log(t, m)
 })
 
 ws.on('error', (m) => {
@@ -61,99 +43,125 @@ ws.on('error', (m) => {
   console.error(m)
 })
 
-ws.on('open', () => {
-  // available types: EXCHANGE_MARKET EXCHANGE_IOC EXCHANGE_LIMIT
-  const order = {
-    symbol: 'EOX.PUSDT',
-    price: '300.5',
-    amount: '-1.09',
-    type: 'EXCHANGE_LIMIT'
-    // clientId: '1332'
-  }
-  ws.place(order)
+const pair = 'EOS.USDT'
+ws.on('open', async () => {
+  // it is required to have read and agreed to our TOS to do trading
+  // get the current TOS version from:
+  // after reading the TOS, you can find them at the bottom of the page
+  // https://www.eosfinex.com/legal/terms/
 
-  ws.onOrderBook({ symbol: 'EOX.PUSDT' }, (ob) => {
-    console.log('ws.onOrderBook({ symbol: "EOX.PUSDT" }')
+  const tos = '$CURRENT_TOS'
+  ws.acceptTos(tos)
+
+  await ws.auth()
+
+  ws.send('pub', { event: 'chain' })
+  ws.send('priv', { event: 'chain' })
+  ws.send('pub', { event: 'pairs' })
+  ws.send('priv', { event: 'pairs' })
+
+  ws.onOrderbook({ symbol: pair }, (ob) => {
+    console.log(`ws.onOrderbook({ symbol: ${pair} })`)
     console.log(ob)
   })
 
+  ws.onManagedOrderbook({ symbol: pair }, (ob) => {
+    console.log(`ws.onManagedOrderbook({ symbol: ${pair} })`)
+    console.log(ob)
+
+    ws.unsubscribeOrderbook(pair)
+  })
+
+  ws.onPublicTrades({}, (data) => {
+    console.log('ws.onPublicTrades({})')
+    console.log('public trade', data)
+  })
+
+  ws.onPublicTrades({ symbol: pair }, (data) => {
+    console.log(`ws.onPublicTrades({ symbol: ${pair} })`)
+    console.log('public trade', data)
+  })
+
+  ws.subscribePublicTrades(pair)
+  ws.subscribeOrderbook(pair)
+
+  // requires auth
   ws.onWallet({}, (wu) => {
-    console.log('ws.onWalletUpdate')
+    console.log('ws.onWallet')
     console.log(wu)
   })
 
-  ws.onManagedWalletUpdate({}, (mw) => {
-    console.log('ws.onManagedWalletUpdate')
+  ws.onManagedWallet({}, (mw) => {
+    console.log('ws.onManagedWallet')
     console.log(mw)
   })
 
-  ws.onManagedOrderbookUpdate({ symbol: 'EOX.PUSDT' }, (ob) => {
-    console.log('ws.onManagedOrderbookUpdate({ symbol: "EOX.PUSDT" }')
-    console.log(ob)
-  })
-
-  // emits all updates
-  ws.onOrderUpdate({}, (data) => {
-    console.log('ws.onOrderUpdate({}')
+  ws.onOrders({}, (data) => {
+    console.log('ws.onOrders({})')
     console.log(data)
   })
 
   // filter enabled
-  ws.onOrderUpdate({ symbol: 'EOX.PUSDT' }, (data) => {
-    console.log('ws.onOrderUpdate({ symbol: "EOX.PUSDT" }')
+  ws.onOrders({ symbol: pair }, (data) => {
+    console.log(`ws.onOrders({ symbol: ${pair} })`)
     console.log(data)
   })
 
-  ws.onOrderUpdate({ symbol: 'EOX.PUSDT' }, (data) => {
-    console.log('ws.onOrderUpdate({ symbol: "EOX.PUSDT" }')
-    console.log(data)
-  })
-
-  ws.onPrivateTradeUpdate({}, (data) => {
-    console.log('ws.onPrivateTradeUpdate({} ')
-    console.log('private trade', data) // emits [ 'ETH.USD', 'te', [ '3', 1537196302500, -0.9, 1 ] ]
-  })
-
-  ws.onPublicTradeUpdate({ symbol: 'EOX.PUSDT' }, (data) => {
-    console.log('ws.onPublicTradeUpdate({} ')
-    console.log('public trade', data)
-  })
-
-  ws.subscribePublicTrades('EOX.PUSDT')
-
-  ws.onManagedOrdersUpdate({}, (orders) => {
+  ws.onManagedOrders({}, (orders) => {
     console.log('ws.onManagedOrdersUpdate')
     console.log(orders)
   })
 
-  ws.subscribeOrderBook('EOX.PUSDT')
+  ws.onManagedOrders({ symbol: pair }, (orders) => {
+    console.log(`ws.onManagedOrders({ symbol: ${pair} }`)
+    console.log(orders)
+  })
 
-  const tos = 'tos_version' // read tos and get current version
-  ws.acceptTos(tos)
+  ws.onPrivateTrades({}, (data) => {
+    console.log('ws.onPrivateTrades({})')
+    console.log('private trade', data) // emits [ 'ETH.USD', 'te', [ '3', 1537196302500, -0.9, 1 ] ]
+  })
+
+  ws.onWallet({}, (wu) => {
+    console.log('ws.onWallet')
+    console.log(wu)
+  })
+
+  ws.onManagedWallet({}, (mw) => {
+    console.log('ws.onManagedWallet')
+    console.log(mw)
+  })
 
   // subscribe to private order updates, wallet updates and trade updates
-  ws.auth()
+  await ws.auth()
 
-  ws.requestHistory().then((history) => {
-    console.log(history.res)
-  })
+  // available types: EXCHANGE_MARKET EXCHANGE_IOC EXCHANGE_LIMIT
+  const order = {
+    symbol: pair,
+    price: '300.5',
+    amount: '1.09',
+    type: 'EXCHANGE_LIMIT'
+    // clientId: '1332'
+  }
+
+  ws.place(order)
 })
 
 setTimeout(() => {
-  console.log('------------ws.getState()')
+  console.log('-- ws.state --')
+  console.log(ws.state)
 
-  console.log(ws.getManagedStateComponent('wallet'))
-  console.log('orders')
-  console.log(ws.getManagedStateComponent('orders'))
-  console.log('books')
-  console.log(ws.getManagedStateComponent('books', 'EOX.PUSDT'))
+  setTimeout(() => {
+    ws.unsubscribe('priv', 'wallets', { account: 'testuser1114' })
+    ws.unsubscribe('priv', 'reports')
+  }, 1000)
 
-  ws.unSubscribeOrderBook('BTC.USD')
-  ws.unSubscribeWallet()
-  ws.unSubscribeOrders()
+  setTimeout(() => {
+    ws.subscribeWallet()
+  }, 5000)
 
   ws.cancel({
-    symbol: 'EOX.PUSDT',
+    symbol: pair,
     side: 'bid',
     id: '18446744073709551612',
     clientId: '1536867193329'
@@ -171,12 +179,13 @@ setTimeout(() => {
   */
 
   const order = {
-    symbol: 'EOX.PUSDT',
+    symbol: pair,
     price: '2300',
     amount: '-14.99',
     type: 'EXCHANGE_LIMIT',
     clientId: '1332'
   }
+
   ws.place(order)
 }, 6000)
 

--- a/lib/sunbeam-ws.js
+++ b/lib/sunbeam-ws.js
@@ -1,15 +1,18 @@
 'use strict'
 
-const MB = require('mandelbrot')
+const EventEmitter = require('events')
 
-const Order = require('./order.js')
+const WsConnect = require('mandelbrot/lib/ws-connect')
+const WsMsgHandler = require('mandelbrot/lib/ws-msg-handler')
+const State = require('mandelbrot/lib/state')
+
+const Orders = require('./managed-orders.js')
+
+const MB = require('mandelbrot')
 const Wallet = MB.BaseWallet
 const Orderbook = MB.R0Orderbook
 
-const Sunbeam = require('./sunbeam-ws.js')
-module.exports = (exports = Sunbeam)
-
-const Orders = require('./managed-orders.js')
+const Order = require('./order.js')
 
 const SignHelper = require('./order-sign.js')
 const SunbeamScatter = require('./scatter.js')
@@ -25,27 +28,36 @@ if (typeof window !== 'undefined') {
   URL = window.URL
 }
 
-class MandelbrotEosfinex extends MB.WsBase {
-  constructor (client, opts = {
-    transform: {},
-    url: null,
-    Wallet: Wallet,
-    Orderbook: Orderbook,
-    Orders: Orders
-  }) {
-    // FIXME: simplify defaults
-    const Ob = opts.Orderbook || Orderbook
-    if (!opts.Orderbook) opts.Orderbook = Ob
-    const Or = opts.Orders || Orders
-    if (!opts.Orders) opts.Orders = Or
-    const W = opts.Wallet || Wallet
-    if (!opts.Wallet) opts.Wallet = W
-    opts.requestTimeout = opts.requestTimeout || 10000
+const _ = require('lodash')
 
-    super(opts)
+class MandelbrotEosfinex extends EventEmitter {
+  constructor (client, opts = {}) {
+    super()
 
-    if (!opts.eos.tokenContract) opts.eos.tokenContract = tokenContract
-    if (!opts.eos.exchangeContract) opts.eos.exchangeContract = exchangeContract
+    const defaults = {
+      eos: {
+        tokenContract,
+        exchangeContract
+      },
+      requestTimeout: 10000,
+      tokenContract,
+      exchangeContract,
+      state: {
+        components: {
+          Wallet,
+          Orderbook,
+          Orders
+        },
+        transform: {
+          orderbook: {},
+          orders: {},
+          wallet: {}
+        }
+      }
+    }
+
+    _.defaultsDeep(opts, defaults)
+    this.conf = opts
 
     this.scatter = null
     if (opts.eos.auth.scatter) {
@@ -55,15 +67,140 @@ class MandelbrotEosfinex extends MB.WsBase {
       })
     }
 
-    this.client = client
-    this.signer = new SignHelper(this.client, opts)
+    if (client) {
+      this.client = client
+      this.signer = new SignHelper(this.client, opts)
+    }
 
     this.account = null
     this.chainId = null
 
     this.cbq = new Cbq()
-
     this.tos = null
+
+    this.transports = Object.keys(opts.urls).reduce((acc, el) => {
+      acc[el] = new WsConnect({
+        url: opts.urls[el]
+      })
+
+      return acc
+    }, {})
+
+    this._state = new State(opts.state)
+    this.msgHandler = new WsMsgHandler({
+      transports: this.transports,
+      state: this._state,
+      customHandler: this.handleRpcCalls.bind(this)
+    })
+
+    this.transportsStatus = {}
+  }
+
+  start () {
+    const transports = Object.keys(this.transports)
+
+    let i = 0
+    transports.forEach((tn) => {
+      const t = this.transports[tn]
+
+      t.on('open', () => {
+        this.registerTransport(tn, true)
+        i++
+
+        if (i === transports.length) {
+          this.emit('open')
+        }
+      })
+
+      t.on('error', (e) => { this.emit('error', e, tn) })
+      t.on('message', (m) => { this.emit('message', m, tn) })
+
+      t.open()
+    })
+  }
+
+  registerTransport (name, connected = true) {
+    this.transportsStatus[name] = { connected }
+  }
+
+  open () {
+    this.start()
+  }
+
+  close () {
+    const transports = Object.keys(this.transports)
+
+    let i = 0
+    transports.forEach((tn) => {
+      this.registerTransport(tn, false)
+
+      const t = this.transports[tn]
+      t.on('close', () => {
+        this.registerTransport(tn, true)
+        i++
+
+        if (i === transports.length) {
+          this.emit('close')
+        }
+      })
+
+      t.close()
+    })
+  }
+
+  get state () {
+    return this._state.state
+  }
+
+  send (transport, msg) {
+    const t = this.transports[transport]
+
+    if (!t) {
+      throw new Error('ERR_MISSING_TRANSPORT')
+    }
+
+    t.send(msg)
+  }
+
+  subscribePublicTrades (symbol) {
+    const { pub } = this.transports
+
+    return pub.subscribe('trades', { symbol })
+  }
+
+  subscribeOrderbook (symbol) {
+    const { pub } = this.transports
+
+    return pub.subscribe('book', { symbol })
+  }
+
+  unsubscribeOrderbook (symbol) {
+    const { pub } = this.transports
+
+    return pub.unsubscribe('book', { symbol })
+  }
+
+  subscribe (transport, channel, args = {}) {
+    const t = this.transports[transport]
+
+    return t.subscribe(channel, args)
+  }
+
+  unsubscribe (transport, channel, args = {}) {
+    const t = this.transports[transport]
+
+    return t.unsubscribe(channel, args)
+  }
+
+  subscribeWallet () {
+    return this.getAuth()
+      .then((auth) => {
+        const { account } = auth
+
+        const { priv } = this.transports
+
+        return priv.subscribe('wallets', { account })
+      })
   }
 
   setAuth (auth = {}) {
@@ -88,8 +225,9 @@ class MandelbrotEosfinex extends MB.WsBase {
   }
 
   sendAuth (user, signed) {
-    this.account = user
+    const { priv } = this.transports
 
+    this.account = user
     const { account } = user
 
     const payload = {
@@ -99,7 +237,7 @@ class MandelbrotEosfinex extends MB.WsBase {
       agree: this.tos
     }
 
-    this.send(payload)
+    priv.send(payload)
   }
 
   auth (data) {
@@ -112,7 +250,7 @@ class MandelbrotEosfinex extends MB.WsBase {
         }
 
         const auth = await this.getAuth()
-        const signed = await this.getSignedTx()
+        const signed = await this.getSignedTx(auth)
         this.sendAuth(auth, signed)
 
         resolve(auth)
@@ -122,33 +260,12 @@ class MandelbrotEosfinex extends MB.WsBase {
     })
   }
 
-  subscribePublicTrades (symbol) {
-    this.send({
-      event: 'subscribe',
-      channel: 'trades',
-      symbol: symbol
-    })
-  }
-
-  subscribeWallet () {
-    return this.getAuth()
-      .then((auth) => {
-        const { account } = auth
-
-        this.send({
-          event: 'subscribe',
-          channel: 'wallets',
-          account: account
-        })
-      })
-  }
-
-  requestChainMeta () {
+  requestChainMeta (transport) {
     return new Promise((resolve, reject) => {
       const { requestTimeout } = this.conf
       const reqId = Math.floor(Math.random() * 10E+15)
 
-      this.sendReqRes({
+      this.sendReqRes(transport, {
         reqId: reqId,
         requestTimeout,
         msg: { event: 'chain' },
@@ -161,28 +278,25 @@ class MandelbrotEosfinex extends MB.WsBase {
     })
   }
 
-  handleInfoMessage (m) {
-    super.handleInfoMessage(m)
+  handleRpcCalls (m) {
+    if (!this.msgHandler.isInfoMsg(m)) {
+      return false
+    }
 
     const [, id, data] = m
 
     if (id === 'ci') {
       this.emit('ci', data)
+      return true
     }
 
     if (id === 'ct') {
       const id = m[2]
       this.emit('ct-' + id, m)
+      return true
     }
-  }
 
-  unSubscribeWallet () {
-    const { account } = this.conf.eos
-    this.unsubscribe('wallets', { account })
-  }
-
-  unSubscribeOrders () {
-    this.unsubscribe('reports')
+    return false
   }
 
   getScope (symbol, side) {
@@ -192,11 +306,11 @@ class MandelbrotEosfinex extends MB.WsBase {
     return symbol.toLowerCase() + '.' + s
   }
 
-  getChainId () {
+  getChainId (transport) {
     return new Promise((resolve, reject) => {
       if (this.chainId) return resolve(this.chainId)
 
-      this.requestChainMeta().then((meta) => {
+      this.requestChainMeta(transport).then((meta) => {
         const [ , , chainId ] = meta
 
         this.chainId = chainId
@@ -205,8 +319,8 @@ class MandelbrotEosfinex extends MB.WsBase {
     })
   }
 
-  async getNetwork () {
-    const chainId = await this.getChainId()
+  async getNetwork (transport) {
+    const chainId = await this.getChainId(transport)
     const { httpEndpoint } = this.conf.eos
     const parsed = new URL(httpEndpoint)
 
@@ -243,11 +357,10 @@ class MandelbrotEosfinex extends MB.WsBase {
           permission: auth.keys.permission
         }
         this.account = res
-
         return resolve(res)
       }
 
-      this.getNetwork()
+      this.getNetwork('priv')
         .then((network) => {
           const opts = { network }
 
@@ -289,7 +402,7 @@ class MandelbrotEosfinex extends MB.WsBase {
           args.id = id
         }
 
-        const meta = await this.requestChainMeta()
+        const meta = await this.requestChainMeta('priv')
         const signed = await this.signer.signTx(
           args,
           auth,
@@ -299,7 +412,7 @@ class MandelbrotEosfinex extends MB.WsBase {
         )
 
         const payload = [0, 'oc', null, { meta: signed }]
-        this.send(payload)
+        this.send('priv', payload)
         resolve({ payload, data: args })
       } catch (e) {
         reject(e)
@@ -311,7 +424,7 @@ class MandelbrotEosfinex extends MB.WsBase {
     return new Promise(async (resolve, reject) => {
       try {
         const auth = await this.getAuth()
-        const meta = await this.requestChainMeta()
+        const meta = await this.requestChainMeta('priv')
         const { exchangeContract } = this.conf.eos
 
         const o = new Order(order, {})
@@ -328,7 +441,7 @@ class MandelbrotEosfinex extends MB.WsBase {
         )
 
         const payload = [0, 'on', null, { meta: signed }]
-        this.send(payload)
+        this.send('priv', payload)
         resolve({ payload, data: o.parsed })
       } catch (e) {
         reject(e)
@@ -357,7 +470,7 @@ class MandelbrotEosfinex extends MB.WsBase {
           to: to || auth.account
         }
 
-        const meta = await this.requestChainMeta()
+        const meta = await this.requestChainMeta('priv')
         const signed = await this.signer.signTx(
           args,
           auth,
@@ -367,7 +480,7 @@ class MandelbrotEosfinex extends MB.WsBase {
         )
 
         const payload = [0, 'tx', null, { meta: signed }]
-        this.send(payload)
+        this.send('priv', payload)
         resolve({ payload, data: args })
       } catch (e) {
         reject(e)
@@ -387,7 +500,7 @@ class MandelbrotEosfinex extends MB.WsBase {
           to: to || auth.account
         }
 
-        const meta = await this.requestChainMeta()
+        const meta = await this.requestChainMeta('priv')
         const signed = await this.signer.signTx(
           args,
           auth,
@@ -397,7 +510,7 @@ class MandelbrotEosfinex extends MB.WsBase {
         )
 
         const payload = [0, 'tx', null, { meta: signed }]
-        this.send(payload)
+        this.send('priv', payload)
         resolve({ payload, data: args })
       } catch (e) {
         reject(e)
@@ -411,7 +524,7 @@ class MandelbrotEosfinex extends MB.WsBase {
     const args = {}
     const { exchangeContract } = this.conf.eos
 
-    const meta = await this.requestChainMeta()
+    const meta = await this.requestChainMeta('priv')
     const signed = await this.signer.signTx(
       args,
       auth,
@@ -423,7 +536,7 @@ class MandelbrotEosfinex extends MB.WsBase {
     return signed
   }
 
-  sendReqRes (req, cb) {
+  sendReqRes (transport, req, cb) {
     const { reqId, requestTimeout, msg, ns } = req
     let timeout
 
@@ -449,10 +562,10 @@ class MandelbrotEosfinex extends MB.WsBase {
       cb(null, res)
     })
 
-    this.send(msg)
+    this.send(transport, msg)
   }
 
-  verifyTx (meta, uuid, opts) {
+  verifyTx (meta, uuid, opts = {}) {
     return new Promise(async (resolve, reject) => {
       try {
         const { requestTimeout } = opts
@@ -463,12 +576,12 @@ class MandelbrotEosfinex extends MB.WsBase {
         const payload = [0, 'ct', uuid, { meta }]
         const data = {
           reqId: uuid,
-          requestTimeout,
+          requestTimeout: requestTimeout || this.conf.requestTimeout,
           msg: payload,
           ns: 'ct-' + uuid
         }
 
-        this.sendReqRes(data, (err, res) => {
+        this.sendReqRes('aux', data, (err, res) => {
           if (err) return reject(err)
           resolve(res)
         })
@@ -501,11 +614,11 @@ class MandelbrotEosfinex extends MB.WsBase {
           account: eos.tokenContract
         }
 
-        const meta = await this.requestChainMeta()
+        const meta = await this.requestChainMeta('priv')
         const signed = await this.signer.signTx(args, auth, 'transfer', meta, tokenContract)
 
         const payload = [0, 'tx', null, { meta: signed }]
-        this.send(payload)
+        this.send('priv', payload)
         resolve({ payload, data: args })
       } catch (e) {
         reject(e)
@@ -514,4 +627,29 @@ class MandelbrotEosfinex extends MB.WsBase {
   }
 }
 
-module.exports = MandelbrotEosfinex
+class Sunbeam {
+  constructor (client, opts) {
+    const w = new MandelbrotEosfinex(client, opts)
+
+    const trap = {
+      get: function (obj, prop) {
+        if (obj[prop]) {
+          return obj[prop]
+        }
+
+        if (/^on.*/.test(prop)) {
+          const hook = obj.msgHandler.addCallback(prop)
+
+          obj[prop] = hook
+          return hook
+        }
+      }
+    }
+
+    var ws = new Proxy(w, trap)
+
+    return ws
+  }
+}
+
+module.exports = Sunbeam

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "cbq": "git+https://github.com/bitfinexcom/cbq-js.git",
     "eosjs": "^20.0.0",
     "isomorphic-ws": "^4.0.1",
-    "mandelbrot": "https://github.com/bitfinexcom/mandelbrot.git#7bf653dbaaeee255ce6c8b76353e56d6ca2f4505",
+    "mandelbrot": "https://github.com/bitfinexcom/mandelbrot.git#34e0ed2b8f4730267304ec6b7dba89b73018ce88",
     "ws": "^6.1.0"
   },
   "browserslist": [

--- a/test/int-sub-unsub-ob.js
+++ b/test/int-sub-unsub-ob.js
@@ -25,7 +25,7 @@ describe('managed state - sub unsub, state stays nice', () => {
     })
 
     const conf = {
-      url: 'ws://localhost:8888',
+      urls: { pub: 'ws://localhost:8888' },
       eos: {
         expireInSeconds: 60 * 60, // 1 hour,
         httpEndpoint: '',
@@ -67,7 +67,7 @@ describe('managed state - sub unsub, state stays nice', () => {
       if (msg.event === 'unsubscribe') {
         subscriptions++
 
-        sws.subscribeOrderBook('BTC.USD')
+        sws.subscribeOrderbook('BTC.USD')
         sendDelayedSub(snapNew, 50)
       }
     }
@@ -77,11 +77,11 @@ describe('managed state - sub unsub, state stays nice', () => {
     }
 
     sws.on('open', () => {
-      sws.subscribeOrderBook('BTC.USD')
+      sws.subscribeOrderbook('BTC.USD')
     })
 
     let count = 0
-    sws.onManagedOrderbookUpdate({ symbol: 'BTC.USD' }, (ob) => {
+    sws.onOrderbook({ symbol: 'BTC.USD' }, (ob) => {
       if (count === 1) {
         count++
       }
@@ -89,7 +89,7 @@ describe('managed state - sub unsub, state stays nice', () => {
       if (count === 0) {
         assert.deepStrictEqual(ob, snap)
         count++
-        sws.unSubscribeOrderBook('BTC.USD')
+        sws.unsubscribeOrderbook('BTC.USD')
       }
 
       if (count === 2) {


### PR DESCRIPTION
 - breaking changes:
  - init of sunbeam takes other options now (regardigng `urls`: for old api, use thrree times the same url)
  - because the websocket adapter had to get decoupled from the state, the message handlers had to get rewritten. with the rewrite i unified the format for the `onXy` handlers

 - `subscribe`, `send`, `unsubscribe`  etc need a transport hint now, example: `ws.send('priv', { event: 'pa' }}`
 
 - docs updates
