### PR TITLE
change key initial implementation

### DIFF
--- a/config/example-ual.config.json.example
+++ b/config/example-ual.config.json.example
@@ -7,12 +7,16 @@
     "eos": {
       "expireInSeconds": 3600,
       "httpEndpoint": "__MAINNET_ENDPOINT__",
-      "exchangeContract": "eosfinextest"
-    },
-    "auth": {
-      "ual": {
-        "accountName": "__ACCOUNT__",
-        "privateKey": "__PRIVATE_KEY__"
+      "exchangeContract": "eosfinextest",
+      "addAuth": {
+        "account": "__ACCOUNT__",
+        "permission": "__PERMISSION__"
+      },
+      "auth": {
+        "ual": {
+          "accountName": "__ACCOUNT__",
+          "privateKey": "__PRIVATE_KEY__"
+        }
       }
     },
     "transform": {

--- a/config/example-ws.config.json.example
+++ b/config/example-ws.config.json.example
@@ -10,6 +10,10 @@
     "eos": {
       "exchangeContract": "__CONTRACT__",
       "expireInSeconds": 129600,
+      "addAuth": {
+        "account": "__ACCOUNT__",
+        "permission": "__PERMISSION__"
+      },
       "httpEndpoint": "http://__API__",
       "auth": {
         "keys": {

--- a/example-ws.js
+++ b/example-ws.js
@@ -20,6 +20,10 @@ const signatureProvider = new JsSignatureProvider(keys)
 
 const rpc = new JsonRpc(httpEndpoint, { fetch })
 const api = new Api({
+  // use available keys to get partially signed transaction on the client side
+  authorityProvider: {
+    getRequiredKeys: () => signatureProvider.getAvailableKeys()
+  },
   rpc,
   signatureProvider,
   textDecoder: new TextDecoder(),
@@ -48,6 +52,23 @@ const pair = 'tBTCUSD'
 const placedOrders = []
 
 ws.on('open', async () => {
+  /*
+  * Pubkey update requires modification of the eosjs api instance.
+  * Modified API instance is required on the Sunbeam instance creation
+  *
+  * const api = new Api({
+  *   // use available keys to get partially signed transaction on the client side
+  *   authorityProvider: {
+  *     getRequiredKeys: () => signatureProvider.getAvailableKeys()
+  *   },
+  *   rpc,
+  *   signatureProvider,
+  *   textDecoder: new TextDecoder(),
+  *   textEncoder: new TextEncoder()
+  * })
+  */
+  // await ws.updateKey({ account: 'dfuser111111', pubkey: 'EOS4yoFY8MChyDzQUk1H6hr7CwEfPmWhRatSqaCCyxk8hJUZZ3uii' })
+
   await ws.auth()
 
   ws.send('priv', { event: 'chain' })

--- a/lib/order-sign.js
+++ b/lib/order-sign.js
@@ -50,6 +50,18 @@ class SignHelper {
   async signTx (payload, auth, action, meta, contract) {
     const opts = this.getSignTxOpts()
     const [transactionHeaders] = this.getTxHeaders(meta)
+    const { account, permission, addAuth } = auth
+    const authorization = [{
+      actor: account,
+      permission: permission
+    }]
+
+    if (addAuth && addAuth.account && addAuth.permission) {
+      authorization.push({
+        actor: addAuth.account,
+        permission: addAuth.permission
+      })
+    }
 
     const txdata = {
       expiration: transactionHeaders.expiration,
@@ -58,10 +70,7 @@ class SignHelper {
       actions: [{
         account: contract,
         name: action,
-        authorization: [{
-          actor: auth.account,
-          permission: auth.permission
-        }],
+        authorization,
         data: payload
       }]
     }

--- a/lib/sunbeam-ws.js
+++ b/lib/sunbeam-ws.js
@@ -284,6 +284,25 @@ class MandelbrotEosfinex extends EventEmitter {
     })
   }
 
+  async updateKey (account, permission, pubkey) {
+    const meta = await this.requestChainMeta('priv')
+    const { exchangeContract } = this.conf.eos
+    const signed = await this.signer.signTx(
+      { account, pubkey },
+      { account, permission },
+      'userkey',
+      meta,
+      exchangeContract
+    )
+
+    const payload = {
+      event: 'changekey',
+      meta: signed
+    }
+
+    this.send('priv', payload)
+  }
+
   async auth (data) {
     this.account = null
 

--- a/lib/sunbeam-ws.js
+++ b/lib/sunbeam-ws.js
@@ -284,12 +284,12 @@ class MandelbrotEosfinex extends EventEmitter {
     })
   }
 
-  async updateKey (account, permission, pubkey) {
+  async updateKey ({ account, permission = 'active', pubkey }) {
     const meta = await this.requestChainMeta('priv')
-    const { exchangeContract } = this.conf.eos
+    const { exchangeContract, addAuth = null } = this.conf.eos
     const signed = await this.signer.signTx(
       { account, pubkey },
-      { account, permission },
+      { account, permission, addAuth },
       'userkey',
       meta,
       exchangeContract

--- a/test/order.js
+++ b/test/order.js
@@ -136,7 +136,9 @@ describe('order helper', () => {
     }, conf)
     const d = Date.now()
     const { order } = ask.serialize()
-
+    ask.ccyMap = {
+      UST: 'USDT'
+    }
     assert.ok(order.nonce - d >= 0 && order.nonce - d <= 1000)
     assert.strictEqual(order.seskey1, conf.seskey1)
     assert.strictEqual(order.seskey2, conf.seskey2)


### PR DESCRIPTION
added `updateKey` method
requires `account` and `pubkey` to be passed. `permission` is optional, defaults to `active`
see `example-ws.js` for the example. Eosjs API instance needs to be modified to support partial signature, which is most probably already done because of `reguser`