### PR TITLE
correct transaction expiration time

### DIFF
--- a/lib/order-sign.js
+++ b/lib/order-sign.js
@@ -9,9 +9,7 @@ class SignHelper {
     this.conf = opts
   }
 
-  getTxHeaders (meta, { expireSeconds } = {}) {
-    expireSeconds = expireSeconds || this.conf.eos.expireInSeconds
-
+  getTxHeaders (meta, { expireSeconds = this.conf.eos.expireInSeconds } = {}) {
     const [
       headBlockTime,
       lastIrreversibleBlockNumber,
@@ -38,8 +36,7 @@ class SignHelper {
     return fixed
   }
 
-  getSignTxOpts ({ broadcast = false, expireInSeconds = null, blocksBehind = 3 } = {}) {
-    expireInSeconds = expireInSeconds || this.conf.eos.expireInSeconds
+  getSignTxOpts ({ broadcast = false, expireInSeconds = this.conf.eos.expireInSeconds, blocksBehind = 3 } = {}) {
     return {
       broadcast,
       blocksBehind,
@@ -48,25 +45,14 @@ class SignHelper {
   }
 
   async signTx (payload, auth, action, meta, contract, txOpts = {}) {
-    const opts = this.getSignTxOpts(txOpts)
-    const [transactionHeaders] = this.getTxHeaders(meta, opts)
     const { account, permission, addAuth } = auth
-    const authorization = [{
-      actor: account,
-      permission: permission
-    }]
+    const authorization = [{ actor: account, permission: permission }]
 
     if (addAuth && addAuth.account && addAuth.permission) {
-      authorization.push({
-        actor: addAuth.account,
-        permission: addAuth.permission
-      })
+      authorization.push({ actor: addAuth.account, permission: addAuth.permission })
     }
 
-    const txdata = {
-      expiration: txOpts.expiration || transactionHeaders.expiration,
-      ref_block_num: transactionHeaders.ref_block_num,
-      ref_block_prefix: transactionHeaders.ref_block_prefix,
+    const txData = {
       actions: [{
         account: contract,
         name: action,
@@ -75,12 +61,25 @@ class SignHelper {
       }]
     }
 
+    const opts = { broadcast: txOpts.broadcast || false }
+
+    if (txOpts.expiration) {
+      const [, lastIrreversibleBlockNumber, , refBlockPrefix] = meta
+      Object.assign(txData, {
+        expiration: txOpts.expiration,
+        ref_block_num: lastIrreversibleBlockNumber & 0xFFFF,
+        ref_block_prefix: +refBlockPrefix
+      })
+    } else {
+      Object.assign(opts, this.getSignTxOpts(txOpts))
+    }
+
     if (this.client.ual) {
-      const res = await this.client.ual.signTransaction(txdata, opts)
+      const res = await this.client.ual.signTransaction(txData, opts)
       return this.fixTx(res.transaction)
     }
 
-    const res = await this.client.api.transact(txdata, opts)
+    const res = await this.client.api.transact(txData, opts)
     return this.fixTx(res)
   }
 }

--- a/lib/order-sign.js
+++ b/lib/order-sign.js
@@ -9,26 +9,6 @@ class SignHelper {
     this.conf = opts
   }
 
-  getTxHeaders (meta, { expireSeconds = this.conf.eos.expireInSeconds } = {}) {
-    const [
-      headBlockTime,
-      lastIrreversibleBlockNumber,
-      chainId,
-      refBlockPrefix
-    ] = meta
-
-    let expiration = new Date(+headBlockTime * 1000 + (expireSeconds * 1000))
-    expiration = expiration.toISOString().split('.')[0]
-
-    const transactionHeaders = {
-      expiration,
-      ref_block_num: lastIrreversibleBlockNumber & 0xFFFF,
-      ref_block_prefix: +refBlockPrefix
-    }
-
-    return [transactionHeaders, chainId]
-  }
-
   fixTx (transfer) {
     const fixed = this.client.api.deserializeTransaction(transfer.serializedTransaction)
     fixed.signatures = transfer.signatures
@@ -61,17 +41,12 @@ class SignHelper {
       }]
     }
 
-    const opts = { broadcast: txOpts.broadcast || false }
+    const opts = this.getSignTxOpts(txOpts)
 
-    if (txOpts.expiration) {
-      const [, lastIrreversibleBlockNumber, , refBlockPrefix] = meta
-      Object.assign(txData, {
-        expiration: txOpts.expiration,
-        ref_block_num: lastIrreversibleBlockNumber & 0xFFFF,
-        ref_block_prefix: +refBlockPrefix
-      })
-    } else {
-      Object.assign(opts, this.getSignTxOpts(txOpts))
+    if (txOpts.expireAt) {
+      const [headBlockTime] = meta
+      opts.expireSeconds = Math.round(txOpts.expireAt.getTime() / 1000) - headBlockTime
+      opts.blocksBehind = 0
     }
 
     if (this.client.ual) {

--- a/lib/order.js
+++ b/lib/order.js
@@ -11,14 +11,13 @@ class Order {
     this.ccyMap = conf.ccyMap || {}
   }
 
-  get expiration () {
+  get expireAt () {
     if (!this.raw.tif || this.raw.type !== 'EXCHANGE LIMIT') {
       return null
     }
     const tifDate = new Date(this.raw.tif)
     // tif + 1 day
-    const expirationDate = new Date(tifDate.getTime() + 86400000)
-    return expirationDate.toISOString().split('.')[0]
+    return new Date(tifDate.getTime() + 86400000)
   }
 
   get parsed () {

--- a/lib/sunbeam-ws.js
+++ b/lib/sunbeam-ws.js
@@ -480,7 +480,7 @@ class MandelbrotEosfinex extends EventEmitter {
       'place',
       meta,
       exchangeContract,
-      { expiration: o.expiration }
+      { expireAt: o.expireAt }
     )
 
     const payload = [0, 'on', null, {


### PR DESCRIPTION
Pass either `expire` and other tx header part or `blocksBehind` + `expireSeconds`. Due to [this](https://github.com/EOSIO/eosjs/blob/20.0.0/src/eosjs-api.ts#L223) logic in the eosjs library, either TAPOS or `blocksBehind` + `expireInSeconds` make sense. In addition to that, TAPOS generated with regards to the head block while `expireInSeconds` takes `blocksBehind` into consideration.