### PR TITLE
compute expiration time based on type of the order

### DIFF
--- a/config/example-ual.config.json.example
+++ b/config/example-ual.config.json.example
@@ -5,7 +5,6 @@
       "priv": "ws://__API__",
     },
     "eos": {
-      "expireInSeconds": 3600,
       "httpEndpoint": "__MAINNET_ENDPOINT__",
       "exchangeContract": "eosfinextest",
       "addAuth": {

--- a/config/example-ws.config.json.example
+++ b/config/example-ws.config.json.example
@@ -9,7 +9,6 @@
     },
     "eos": {
       "exchangeContract": "__CONTRACT__",
-      "expireInSeconds": 129600,
       "addAuth": {
         "account": "__ACCOUNT__",
         "permission": "__PERMISSION__"

--- a/lib/order-sign.js
+++ b/lib/order-sign.js
@@ -4,9 +4,9 @@
 // needs http to get contract abis from an eos node.
 
 class SignHelper {
-  constructor (client, opts) {
+  constructor (client) {
     this.client = client
-    this.conf = opts
+    this.expireInSeconds = 24 * 60 * 60
   }
 
   fixTx (transfer) {
@@ -16,7 +16,22 @@ class SignHelper {
     return fixed
   }
 
-  getSignTxOpts ({ broadcast = false, expireInSeconds = this.conf.eos.expireInSeconds, blocksBehind = 3 } = {}) {
+  getSignTxOpts ({
+    broadcast = false,
+    expireInSeconds = this.expireInSeconds,
+    expireAt = null,
+    blocksBehind = 3,
+    meta
+  } = {}) {
+    if (expireAt) {
+      if (!meta) {
+        throw new Error('Meta required')
+      }
+      const [headBlockTime] = meta
+      expireInSeconds = Math.round(expireAt.getTime() / 1000) - headBlockTime
+      blocksBehind = 0
+    }
+
     return {
       broadcast,
       blocksBehind,
@@ -41,13 +56,7 @@ class SignHelper {
       }]
     }
 
-    const opts = this.getSignTxOpts(txOpts)
-
-    if (txOpts.expireAt) {
-      const [headBlockTime] = meta
-      opts.expireSeconds = Math.round(txOpts.expireAt.getTime() / 1000) - headBlockTime
-      opts.blocksBehind = 0
-    }
+    const opts = this.getSignTxOpts({ ...txOpts, meta })
 
     if (this.client.ual) {
       const res = await this.client.ual.signTransaction(txData, opts)

--- a/lib/order.js
+++ b/lib/order.js
@@ -11,13 +11,21 @@ class Order {
     this.ccyMap = conf.ccyMap || {}
   }
 
-  get expireAt () {
-    if (!this.raw.tif || this.raw.type !== 'EXCHANGE LIMIT') {
-      return null
+  get expirationInfo () {
+    if (this.raw.type === 'EXCHANGE LIMIT') {
+      if (this.raw.tif) {
+        const tifDate = new Date(this.raw.tif)
+        // tif + 1 day
+        const expirationDate = new Date(tifDate.getTime() + 86400000)
+        return { expireAt: expirationDate }
+      }
+
+      // 7 days
+      return { expireInSeconds: 604800 }
     }
-    const tifDate = new Date(this.raw.tif)
-    // tif + 1 day
-    return new Date(tifDate.getTime() + 86400000)
+
+    // 1 day
+    return { expireInSeconds: 86400 }
   }
 
   get parsed () {

--- a/lib/sunbeam-ws.js
+++ b/lib/sunbeam-ws.js
@@ -36,7 +36,6 @@ class MandelbrotEosfinex extends EventEmitter {
     const defaults = {
       eos: {
         exchangeContract,
-        expireInSeconds: 7 * 24 * 60 * 60,
         auth: {}
       },
       requestTimeout: 10000,
@@ -96,7 +95,7 @@ class MandelbrotEosfinex extends EventEmitter {
 
   setClient (client) {
     this.client = client
-    this.signer = new SignHelper(this.client, this.conf)
+    this.signer = new SignHelper(this.client)
   }
 
   setMaxListeners (n) {
@@ -285,13 +284,12 @@ class MandelbrotEosfinex extends EventEmitter {
   }
 
   async updateKey ({ account, permission = 'active', pubkey }) {
-    const meta = await this.requestChainMeta('priv')
     const { exchangeContract, addAuth = null } = this.conf.eos
     const signed = await this.signer.signTx(
       { account, pubkey },
       { account, permission, addAuth },
       'userkey',
-      meta,
+      null,
       exchangeContract,
       { expireInSeconds: 3600 }
     )
@@ -480,7 +478,7 @@ class MandelbrotEosfinex extends EventEmitter {
       'place',
       meta,
       exchangeContract,
-      { expireAt: o.expireAt }
+      o.expirationInfo
     )
 
     const payload = [0, 'on', null, {
@@ -500,12 +498,11 @@ class MandelbrotEosfinex extends EventEmitter {
     }
     const { exchangeContract } = this.conf.eos
 
-    const meta = await this.requestChainMeta('priv')
     const signed = await this.signer.signTx(
       args,
       auth,
       'validate',
-      meta,
+      null,
       exchangeContract
     )
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sunbeam",
-  "version": "9.0.0",
+  "version": "9.0.1",
   "description": "JS lib for eosfinex",
   "main": "lib/index.js",
   "scripts": {

--- a/test/order.js
+++ b/test/order.js
@@ -69,6 +69,75 @@ describe('order helper', () => {
     assert.strictEqual(ask.parsed.flags, 0)
   })
 
+  it('sets tif for EXCHANGE LIMIT', () => {
+    const ask = new Order({
+      symbol: 'tBTCUSD',
+      amount: '-0.99',
+      price: 520,
+      type: 'EXCHANGE LIMIT',
+      tif: 1608124922253,
+      flags: 4096
+    }, conf)
+
+    assert.deepStrictEqual(ask.parsed.tif, '2020-12-16 13:22:02')
+  })
+
+  it('skips tif for not EXCHANGE LIMIT', () => {
+    const ask = new Order({
+      symbol: 'tBTCUSD',
+      amount: '-0.99',
+      price: 520,
+      type: 'EXCHANGE MARKET',
+      tif: 1608124922253,
+      flags: 4096
+    }, conf)
+
+    assert.deepStrictEqual(ask.parsed.tif, undefined)
+  })
+
+  it('returns expire datetime string as tif + 1 day for EXCHANGE LIMIT with tif', () => {
+    const expireMs = 1608036760427 // 2020-12-15T12:52:40.427Z
+    const ask = new Order({
+      symbol: 'tBTCUSD',
+      amount: '-0.99',
+      price: 520,
+      type: 'EXCHANGE LIMIT',
+      tif: expireMs,
+      flags: 4096
+    }, conf)
+
+    const { expireAt } = ask.expirationInfo
+    assert.deepStrictEqual(expireAt.toISOString(), '2020-12-16T12:52:40.427Z')
+  })
+
+  it('returns 7 day expireInSeconds EXCHANGE LIMIT', () => {
+    const ask = new Order({
+      symbol: 'tBTCUSD',
+      amount: '-0.99',
+      price: 520,
+      type: 'EXCHANGE LIMIT',
+      flags: 4096
+    }, conf)
+
+    assert.deepStrictEqual(ask.expirationInfo, {
+      expireInSeconds: 7 * 24 * 60 * 60
+    })
+  })
+
+  it('returns 1 day expireInSeconds', () => {
+    const ask = new Order({
+      symbol: 'tBTCUSD',
+      amount: '-0.99',
+      price: 520,
+      type: 'EXCHANGE MARKET',
+      flags: 4096
+    }, conf)
+
+    assert.deepStrictEqual(ask.expirationInfo, {
+      expireInSeconds: 24 * 60 * 60
+    })
+  })
+
   it('builds message object from parsed value', () => {
     const ask = new Order({
       symbol: 'tBTCUSD',


### PR DESCRIPTION
* Omit chain meta request when `expireInSeconds` is used. `eosjs` calculates it internally no matter what.
* Tie expiration time to the transaction / order type. Remove it from config
  * EXCHANGE LIMIT expiration time = head block time + 7 days
  * EXCHANGE LIMIT + tif expiration time = tif + 1 day
  * all other cases (new orders, deposit, etc) = head block time + 1 day