### PR TITLE
compute tapos fields, use last irreversible block

### DIFF
--- a/lib/order-sign.js
+++ b/lib/order-sign.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { reverseHex } = require('./util')
+
 // this is a helper class for signing transactions
 // needs http to get contract abis from an eos node.
 
@@ -16,30 +18,19 @@ class SignHelper {
     return fixed
   }
 
-  getSignTxOpts ({
-    broadcast = false,
-    expireInSeconds = this.expireInSeconds,
-    expireAt = null,
-    blocksBehind = 3,
-    meta
-  } = {}) {
-    if (expireAt) {
-      if (!meta) {
-        throw new Error('Meta required')
-      }
-      const [headBlockTime] = meta
-      expireInSeconds = Math.round(expireAt.getTime() / 1000) - headBlockTime
-      blocksBehind = 0
-    }
+  async getTxHeader ({ expireInSeconds = 86400, expireAt = null } = {}) {
+    const { last_irreversible_block_num: libn, last_irreversible_block_id: libi } = await this.client.rpc.get_info()
+    const prefix = parseInt(reverseHex(libi.substr(16, 8)), 16)
+    const expirationDate = expireAt || new Date(Date.now() + expireInSeconds * 1000)
 
     return {
-      broadcast,
-      blocksBehind,
-      expireSeconds: expireInSeconds
+      expiration: expirationDate.toISOString().split('.')[0],
+      ref_block_num: libn & 0xffff,
+      ref_block_prefix: prefix
     }
   }
 
-  async signTx (payload, auth, action, meta, contract, txOpts = {}) {
+  async signTx (payload, auth, action, contract, txOpts = {}) {
     const { account, permission, addAuth } = auth
     const authorization = [{ actor: account, permission: permission }]
 
@@ -47,7 +38,10 @@ class SignHelper {
       authorization.push({ actor: addAuth.account, permission: addAuth.permission })
     }
 
+    const txHeader = await this.getTxHeader(txOpts)
+
     const txData = {
+      ...txHeader,
       actions: [{
         account: contract,
         name: action,
@@ -56,7 +50,7 @@ class SignHelper {
       }]
     }
 
-    const opts = this.getSignTxOpts({ ...txOpts, meta })
+    const opts = { broadcast: txOpts.broadcast || false }
 
     if (this.client.ual) {
       const res = await this.client.ual.signTransaction(txData, opts)

--- a/lib/sunbeam-ws.js
+++ b/lib/sunbeam-ws.js
@@ -289,7 +289,6 @@ class MandelbrotEosfinex extends EventEmitter {
       { account, pubkey },
       { account, permission, addAuth },
       'userkey',
-      null,
       exchangeContract,
       { expireInSeconds: 3600 }
     )
@@ -464,7 +463,6 @@ class MandelbrotEosfinex extends EventEmitter {
 
   async place (order) {
     const auth = await this.getAuth()
-    const meta = await this.requestChainMeta('priv')
     const { exchangeContract } = this.conf.eos
     const { _key1: seskey1, _key2: seskey2, ccyMap } = this
 
@@ -476,7 +474,6 @@ class MandelbrotEosfinex extends EventEmitter {
       serialized,
       auth,
       'place',
-      meta,
       exchangeContract,
       o.expirationInfo
     )
@@ -502,7 +499,6 @@ class MandelbrotEosfinex extends EventEmitter {
       args,
       auth,
       'validate',
-      null,
       exchangeContract
     )
 
@@ -568,7 +564,8 @@ class MandelbrotEosfinex extends EventEmitter {
       }
     })
 
-    const txResult = await this.client.api.transact({ actions }, this.signer.getSignTxOpts({ broadcast: true }))
+    const txHeader = await this.signer.getTxHeader()
+    const txResult = await this.client.api.transact({ ...txHeader, actions }, { broadcast: true })
 
     return { txResult, txData }
   }
@@ -617,7 +614,8 @@ class MandelbrotEosfinex extends EventEmitter {
       }
     })
 
-    const txResult = await this.client.api.transact({ actions }, this.signer.getSignTxOpts({ broadcast: true }))
+    const txHeader = await this.signer.getTxHeader()
+    const txResult = await this.client.api.transact({ ...txHeader, actions }, { broadcast: true })
 
     return { txResult, txData }
   }

--- a/lib/util.js
+++ b/lib/util.js
@@ -62,6 +62,12 @@ function decimalString (value) {
   return (neg ? '-' : '') + part.join('.')
 }
 
+// taken from https://github.com/EOSIO/eosjs/blob/1cf9bf53d21d3f461f61970d3295ee1fc2ba56d1/src/eosjs-serialize.ts
+// MIT license
+exports.reverseHex = h => {
+  return h.substr(6, 2) + h.substr(4, 2) + h.substr(2, 2) + h.substr(0, 2)
+}
+
 exports.txToArr = txToArr
 function txToArr (eObjOrder) {
   const result = []


### PR DESCRIPTION
Issue description:
`ual-anchor` doesn't take transaction options like `expireSeconds` or `blocksBehind` into account. Tapos fields should be included in the transaction in order to set expiration time
* [signTransaction](https://github.com/greymass/ual-anchor/blob/master/src/AnchorUser.ts#L38) calls [transact](https://github.com/greymass/anchor-link/blob/9e8df0941feeba185356cdeb5786a6ab6ab43126/src/link.ts#L299), which takes only `broadcast` into account
* then, [createRequest](https://github.com/greymass/anchor-link/blob/9e8df0941feeba185356cdeb5786a6ab6ab43126/src/link.ts#L182) is called, which calls [create](https://github.com/greymass/eosio-signing-request/blob/master/src/signing-request.ts#L245). Options param is not used anywhere, except to retrieve `broadcast` flag
* [create](https://github.com/greymass/eosio-signing-request/blob/master/src/signing-request.ts#L268) uses defaults as tapos if none have been provided, which results in expiration time for transactions signed by anchor being set to current time while plugin requires at least 24h

Changes description:
* required tapos fields are calculated on the same way as it's done in [eosjs](https://github.com/EOSIO/eosjs/blob/1cf9bf53d21d3f461f61970d3295ee1fc2ba56d1/src/eosjs-api.ts#L277)
* last irreversible block is used as a reference
* chain information requested through API instead of plugin as plugin now internally uses API